### PR TITLE
Update AccessConfig-required.mdx

### DIFF
--- a/builder/common/access_config.go
+++ b/builder/common/access_config.go
@@ -95,10 +95,9 @@ func (v *VaultAWSEngineOptions) Empty() bool {
 
 // AccessConfig is for common configuration related to AWS access
 type AccessConfig struct {
-	// The access key used to communicate with AWS. [Learn how  to set this]
-	// (/docs/builders/amazon#specifying-amazon-credentials). On EBS, this
-	// is not required if you are using `use_vault_aws_engine` for
-	// authentication instead.
+	// The access key used to communicate with AWS. [Learn how  to set this](/docs/builders/amazon#specifying-amazon-credentials).
+	// On EBS, this is not required if you are using `use_vault_aws_engine`
+	// for authentication instead.
 	AccessKey string `mapstructure:"access_key" required:"true"`
 	// If provided with a role ARN, Packer will attempt to assume this role
 	// using the supplied credentials. See

--- a/docs-partials/builder/common/AccessConfig-required.mdx
+++ b/docs-partials/builder/common/AccessConfig-required.mdx
@@ -1,9 +1,8 @@
 <!-- Code generated from the comments of the AccessConfig struct in builder/common/access_config.go; DO NOT EDIT MANUALLY -->
 
-- `access_key` (string) - The access key used to communicate with AWS. [Learn how  to set 
-this](/docs/builders/amazon#specifying-amazon-credentials). On EBS, this
-  is not required if you are using `use_vault_aws_engine` for
-  authentication instead.
+- `access_key` (string) - The access key used to communicate with AWS. [Learn how  to set this](/docs/builders/amazon#specifying-amazon-credentials).
+  On EBS, this is not required if you are using `use_vault_aws_engine`
+  for authentication instead.
 
 - `region` (string) - The name of the region, such as `us-east-1`, in which
   to launch the EC2 instance to create the AMI.

--- a/docs-partials/builder/common/AccessConfig-required.mdx
+++ b/docs-partials/builder/common/AccessConfig-required.mdx
@@ -1,7 +1,7 @@
 <!-- Code generated from the comments of the AccessConfig struct in builder/common/access_config.go; DO NOT EDIT MANUALLY -->
 
-- `access_key` (string) - The access key used to communicate with AWS. [Learn how  to set this]
-  (/docs/builders/amazon#specifying-amazon-credentials). On EBS, this
+- `access_key` (string) - The access key used to communicate with AWS. [Learn how  to set 
+this](/docs/builders/amazon#specifying-amazon-credentials). On EBS, this
   is not required if you are using `use_vault_aws_engine` for
   authentication instead.
 


### PR DESCRIPTION
fix markdown link to `/docs/builders/amazon#specifying-amazon-credentials`


