### PR TITLE
Update import.mdx

### DIFF
--- a/docs/post-processors/import.mdx
+++ b/docs/post-processors/import.mdx
@@ -31,7 +31,7 @@ The import process itself run by AWS includes modifications to the image
 uploaded, to allow it to boot and operate in the AWS EC2 environment. However,
 not all modifications required to make the machine run well in EC2 are
 performed. Take care around console output from the machine, as debugging can
-be very difficult without it. On the source OVA artifact makse sure to include 
+be very difficult without it. On the source OVA artifact make sure to include 
 tools suitable for instances in EC2 such as the `cloud-init` package for Linux.
 
 Further information about the import process can be found in AWS's [EC2

--- a/docs/post-processors/import.mdx
+++ b/docs/post-processors/import.mdx
@@ -31,8 +31,8 @@ The import process itself run by AWS includes modifications to the image
 uploaded, to allow it to boot and operate in the AWS EC2 environment. However,
 not all modifications required to make the machine run well in EC2 are
 performed. Take care around console output from the machine, as debugging can
-be very difficult without it. You may also want to include tools suitable for
-instances in EC2 such as `cloud-init` for Linux.
+be very difficult without it. On the source OVA artifact makse sure to include 
+tools suitable for instances in EC2 such as the `cloud-init` package for Linux.
 
 Further information about the import process can be found in AWS's [EC2
 Import/Export Instance


### PR DESCRIPTION
Update in the documentation to describe the need for `cloud-init`  in linux systems.

If package is not present, proper provisioning will fail for new EC2 instances.

