### PR TITLE
Add Packer and packer-plugin-amazon to the User-Agent header

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -285,7 +285,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	var warns []string
 
 	errs = packersdk.MultiErrorAppend(errs, b.config.RootVolumeTag.CopyOn(&b.config.RootVolumeTags)...)
-	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare(&b.config.PackerConfig)...)
 	errs = packersdk.MultiErrorAppend(errs,
 		b.config.AMIConfig.Prepare(&b.config.AccessConfig, &b.config.ctx)...)
 

--- a/builder/common/access_config_test.go
+++ b/builder/common/access_config_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/hashicorp/packer-plugin-sdk/common"
 )
 
 func TestAccessConfigPrepare_Region(t *testing.T) {
@@ -37,11 +38,31 @@ func TestAccessConfigPrepare_RegionRestricted(t *testing.T) {
 		Region: aws.String("us-gov-west-1"),
 	}))
 
-	if err := c.Prepare(); err != nil {
+	packerConfig := &common.PackerConfig{
+		PackerCoreVersion: "0.0.0",
+	}
+	if err := c.Prepare(packerConfig); err != nil {
 		t.Fatalf("shouldn't have err: %s", err)
 	}
 
 	if !c.IsGovCloud() {
 		t.Fatal("We should be in gov region.")
+	}
+}
+
+func TestAccessConfigPrepare_UnknownPackerCoreVersion(t *testing.T) {
+	c := FakeAccessConfig()
+
+	// Create a Session with a custom region
+	c.session = session.Must(session.NewSession(&aws.Config{
+		Region: aws.String("us-east-1"),
+	}))
+
+	if err := c.Prepare(nil); err != nil {
+		t.Fatalf("shouldn't have err: %s", err)
+	}
+
+	if c.packerConfig.PackerCoreVersion != "unknown" {
+		t.Fatalf("packer core version should be unknown, but got %s", c.packerConfig.PackerCoreVersion)
 	}
 }

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -121,7 +121,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	errs = packersdk.MultiErrorAppend(errs, b.config.VolumeRunTag.CopyOn(&b.config.VolumeRunTags)...)
 
-	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare(&b.config.PackerConfig)...)
 	errs = packersdk.MultiErrorAppend(errs,
 		b.config.AMIConfig.Prepare(&b.config.AccessConfig, &b.config.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, b.config.AMIMappings.Prepare(&b.config.ctx)...)

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -116,7 +116,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	var warns []string
 	errs = packersdk.MultiErrorAppend(errs, b.config.VolumeRunTag.CopyOn(&b.config.VolumeRunTags)...)
 
-	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare(&b.config.PackerConfig)...)
 	errs = packersdk.MultiErrorAppend(errs, b.config.RunConfig.Prepare(&b.config.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs,
 		b.config.AMIConfig.Prepare(&b.config.AccessConfig, &b.config.ctx)...)

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -125,7 +125,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	var warns []string
 
 	errs = packersdk.MultiErrorAppend(errs, b.config.VolumeRunTag.CopyOn(&b.config.VolumeRunTags)...)
-	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare(&b.config.PackerConfig)...)
 	errs = packersdk.MultiErrorAppend(errs, b.config.RunConfig.Prepare(&b.config.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, b.config.launchBlockDevices.Prepare(&b.config.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, b.config.VolumeMappings.Prepare(&b.config.ctx)...)

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -178,7 +178,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	// Accumulate any errors
 	var errs *packersdk.MultiError
 	var warns []string
-	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, b.config.AccessConfig.Prepare(&b.config.PackerConfig)...)
 	errs = packersdk.MultiErrorAppend(errs, b.config.AMIMappings.Prepare(&b.config.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs, b.config.LaunchMappings.Prepare(&b.config.ctx)...)
 	errs = packersdk.MultiErrorAppend(errs,

--- a/datasource/ami/data.go
+++ b/datasource/ami/data.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/hcl/v2/hcldec"
 	awscommon "github.com/hashicorp/packer-plugin-amazon/builder/common"
+	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/hcl2helper"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
@@ -20,6 +21,7 @@ type Datasource struct {
 }
 
 type Config struct {
+	common.PackerConfig        `mapstructure:",squash"`
 	awscommon.AccessConfig     `mapstructure:",squash"`
 	awscommon.AmiFilterOptions `mapstructure:",squash"`
 }
@@ -35,7 +37,7 @@ func (d *Datasource) Configure(raws ...interface{}) error {
 	}
 
 	var errs *packersdk.MultiError
-	errs = packersdk.MultiErrorAppend(errs, d.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, d.config.AccessConfig.Prepare(&d.config.PackerConfig)...)
 
 	if d.config.Empty() {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("The `filters` must be specified"))

--- a/datasource/secretsmanager/data.go
+++ b/datasource/secretsmanager/data.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hcldec"
 	awscommon "github.com/hashicorp/packer-plugin-amazon/builder/common"
 	"github.com/hashicorp/packer-plugin-amazon/builder/common/awserrors"
+	"github.com/hashicorp/packer-plugin-sdk/common"
 	"github.com/hashicorp/packer-plugin-sdk/hcl2helper"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
@@ -23,6 +24,7 @@ type Datasource struct {
 }
 
 type Config struct {
+	common.PackerConfig `mapstructure:",squash"`
 	// Specifies the secret containing the version that you want to retrieve.
 	// You can specify either the Amazon Resource Name (ARN) or the friendly name of the secret.
 	Name string `mapstructure:"name" required:"true"`
@@ -49,7 +51,7 @@ func (d *Datasource) Configure(raws ...interface{}) error {
 	}
 
 	var errs *packersdk.MultiError
-	errs = packersdk.MultiErrorAppend(errs, d.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, d.config.AccessConfig.Prepare(&d.config.PackerConfig)...)
 
 	if d.config.Name == "" {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("a 'name' must be provided"))

--- a/main.go
+++ b/main.go
@@ -12,22 +12,15 @@ import (
 	"github.com/hashicorp/packer-plugin-amazon/datasource/ami"
 	"github.com/hashicorp/packer-plugin-amazon/datasource/secretsmanager"
 	amazonimport "github.com/hashicorp/packer-plugin-amazon/post-processor/import"
+	pluginversion "github.com/hashicorp/packer-plugin-amazon/version"
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
 	"github.com/hashicorp/packer-plugin-sdk/version"
 )
 
 var (
-	// Version is the main version number that is being run at the moment.
-	Version = "0.0.2"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
-
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.
-	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+	PluginVersion = version.InitializePluginVersion(pluginversion.Version, pluginversion.VersionPrerelease)
 )
 
 func main() {

--- a/post-processor/import/post-processor.go
+++ b/post-processor/import/post-processor.go
@@ -90,7 +90,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	// Check we have AWS access variables defined somewhere
-	errs = packersdk.MultiErrorAppend(errs, p.config.AccessConfig.Prepare()...)
+	errs = packersdk.MultiErrorAppend(errs, p.config.AccessConfig.Prepare(&p.config.PackerConfig)...)
 
 	// define all our required parameters
 	templates := map[string]*string{

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+var (
+	// Version is the main version number that is being run at the moment.
+	Version = "0.0.2"
+
+	// VersionPrerelease is A pre-release marker for the Version. If this is ""
+	// (empty string) then it means that it is a final release. Otherwise, this
+	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease = "dev"
+)


### PR DESCRIPTION
Resolves hashicorp/packer#10315, by adding the plugin version to the User-Agent header sent by the AWS SDK. This is code copied from [session.go in aws-sdk-go-base](https://github.com/hashicorp/aws-sdk-go-base/blob/da4108d88728fcf4f5f9df9ea817285bccf7078e/session.go#L105). 