### PR TITLE
small fix to hcl2 source_ami_filter example

### DIFF
--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -166,7 +166,7 @@
     source_ami_filter {
       filters = {
          virtualization-type = "hvm"
-         name = "ubuntu/images/\*ubuntu-xenial-16.04-amd64-server-\*"
+         name = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
          root-device-type = "ebs"
       }
       owners = ["099720109477"]


### PR DESCRIPTION
Sample code didn't work in packer 1.7.2.  Had to remove the `\`

excerpt from failing code
```
  60:        name = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-\*"

The symbol "*" is not a valid escape sequence selector.
```