### PR TITLE
goreleaser - point to the correct version package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ builds:
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
-      - '-s -w -X main.Version={{.Version}} -X main.VersionPrerelease= '
+      - '-s -w -X github.com/hashicorp/{{ .ProjectName }}/version.Version={{.Version}} -X github.com/hashicorp/{{ .ProjectName }}/version.VersionPrerelease= '
     goos:
       - linux
     goarch:
@@ -36,7 +36,7 @@ builds:
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.VersionPrerelease= '
+      - '-s -w -X github.com/hashicorp/{{ .ProjectName }}/version.Version={{.Version}} -X github.com/hashicorp/{{ .ProjectName }}/version.VersionPrerelease= '
     goos:
       - freebsd
       - windows


### PR DESCRIPTION
https://github.com/hashicorp/packer-plugin-amazon/pull/82 breaks the versioning automation and this is the fix.