### PR TITLE
Moving DeprecationTime field to the config in ebs/builder.go

### DIFF
--- a/builder/common/ami_config.go
+++ b/builder/common/ami_config.go
@@ -3,11 +3,9 @@
 package common
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
-	"time"
 
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
@@ -139,10 +137,6 @@ type AMIConfig struct {
 	AMISkipBuildRegion bool `mapstructure:"skip_save_build_region"`
 
 	SnapshotConfig `mapstructure:",squash"`
-	// The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
-	// If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
-	// You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
-	DeprecationTime string `mapstructure:"deprecate_at"`
 }
 
 func stringInSlice(s []string, searchstr string) bool {
@@ -239,10 +233,6 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 			"filter to automatically clean your ami name."))
 	}
 
-	if err := c.validateDeprecationTime(); err != nil {
-		errs = append(errs, err)
-	}
-
 	if len(errs) > 0 {
 		return errs
 	}
@@ -303,15 +293,4 @@ func ValidateKmsKey(kmsKey string) (valid bool) {
 		return true
 	}
 	return false
-}
-
-func (c *AMIConfig) validateDeprecationTime() error {
-	if c.DeprecationTime == "" {
-		return nil
-	}
-	_, err := time.Parse(time.RFC3339, c.DeprecationTime)
-	if err != nil {
-		return errors.New("deprecate_at is not a valid time. Expect time format: YYYY-MM-DDTHH:MM:SSZ")
-	}
-	return nil
 }

--- a/builder/common/ami_config_test.go
+++ b/builder/common/ami_config_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -242,31 +241,4 @@ func TestAMINameValidation(t *testing.T) {
 		t.Fatalf("expected `xyz-base-2017-04-05-1934` to pass validation.")
 	}
 
-}
-
-func TestAMIConfigPrepare_DeprecationTime(t *testing.T) {
-	c := testAMIConfig()
-	accessConf := FakeAccessConfig()
-
-	currentTime := time.Now().UTC()
-	testcases := []struct {
-		name            string
-		deprecationTime string
-		isErr           bool
-	}{
-		{"good", currentTime.Format(time.RFC3339), false},
-		{"not in format (YYYY-MM-DDTHH:MM:SSZ)", currentTime.Format(time.ANSIC), true},
-	}
-	for _, tc := range testcases {
-		t.Run(fmt.Sprintf("%s_%s", tc.deprecationTime, tc.name), func(t *testing.T) {
-			c.DeprecationTime = tc.deprecationTime
-			err := c.Prepare(accessConf, nil)
-			if tc.isErr && err == nil {
-				t.Error("Expect error")
-			}
-			if !tc.isErr && err != nil {
-				t.Errorf("Expect no error. got %s", err)
-			}
-		})
-	}
 }

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -11,6 +11,7 @@ package ebs
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -74,6 +75,10 @@ type Config struct {
 	// make sure you don't set this for *nix guests; behavior may be
 	// unpredictable.
 	NoEphemeral bool `mapstructure:"no_ephemeral" required:"false"`
+	// The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
+	// If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
+	// You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
+	DeprecationTime string `mapstructure:"deprecate_at"`
 
 	ctx interpolate.Context
 }
@@ -135,6 +140,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			fmt.Errorf("Spot instances do not support modification, which is required "+
 				"when either `ena_support` or `sriov_support` are set. Please ensure "+
 				"you use an AMI that already has either SR-IOV or ENA enabled."))
+	}
+
+	if b.config.DeprecationTime != "" {
+		if _, err := time.Parse(time.RFC3339, b.config.DeprecationTime); err != nil {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf("deprecate_at is not a valid time. Expect time format: YYYY-MM-DDTHH:MM:SSZ"))
+		}
 	}
 
 	if b.config.RunConfig.SpotPriceAutoProduct != "" {

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -58,7 +58,6 @@ type FlatConfig struct {
 	SnapshotTag                               []config.FlatKeyValue                  `mapstructure:"snapshot_tag" required:"false" cty:"snapshot_tag" hcl:"snapshot_tag"`
 	SnapshotUsers                             []string                               `mapstructure:"snapshot_users" required:"false" cty:"snapshot_users" hcl:"snapshot_users"`
 	SnapshotGroups                            []string                               `mapstructure:"snapshot_groups" required:"false" cty:"snapshot_groups" hcl:"snapshot_groups"`
-	DeprecationTime                           *string                                `mapstructure:"deprecate_at" cty:"deprecate_at" hcl:"deprecate_at"`
 	AssociatePublicIpAddress                  *bool                                  `mapstructure:"associate_public_ip_address" required:"false" cty:"associate_public_ip_address" hcl:"associate_public_ip_address"`
 	AvailabilityZone                          *string                                `mapstructure:"availability_zone" required:"false" cty:"availability_zone" hcl:"availability_zone"`
 	BlockDurationMinutes                      *int64                                 `mapstructure:"block_duration_minutes" required:"false" cty:"block_duration_minutes" hcl:"block_duration_minutes"`
@@ -152,6 +151,7 @@ type FlatConfig struct {
 	VolumeRunTags                             map[string]string                      `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
 	VolumeRunTag                              []config.FlatNameValue                 `mapstructure:"run_volume_tag" required:"false" cty:"run_volume_tag" hcl:"run_volume_tag"`
 	NoEphemeral                               *bool                                  `mapstructure:"no_ephemeral" required:"false" cty:"no_ephemeral" hcl:"no_ephemeral"`
+	DeprecationTime                           *string                                `mapstructure:"deprecate_at" cty:"deprecate_at" hcl:"deprecate_at"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -212,7 +212,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"snapshot_tag":                  &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":                &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},
 		"snapshot_groups":               &hcldec.AttrSpec{Name: "snapshot_groups", Type: cty.List(cty.String), Required: false},
-		"deprecate_at":                  &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"associate_public_ip_address":   &hcldec.AttrSpec{Name: "associate_public_ip_address", Type: cty.Bool, Required: false},
 		"availability_zone":             &hcldec.AttrSpec{Name: "availability_zone", Type: cty.String, Required: false},
 		"block_duration_minutes":        &hcldec.AttrSpec{Name: "block_duration_minutes", Type: cty.Number, Required: false},
@@ -306,6 +305,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"run_volume_tags":                       &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},
 		"run_volume_tag":                        &hcldec.BlockListSpec{TypeName: "run_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatNameValue)(nil).HCL2Spec())},
 		"no_ephemeral":                          &hcldec.AttrSpec{Name: "no_ephemeral", Type: cty.Bool, Required: false},
+		"deprecate_at":                          &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/common/AMIConfig-not-required.mdx
+++ b/docs-partials/builder/common/AMIConfig-not-required.mdx
@@ -117,8 +117,4 @@
   the intermediary AMI into any regions provided in `ami_regions`, then
   delete the intermediary AMI. Default `false`.
 
-- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
-  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
-  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
-
 <!-- End of code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; -->

--- a/docs-partials/builder/ebs/Config-not-required.mdx
+++ b/docs-partials/builder/ebs/Config-not-required.mdx
@@ -40,4 +40,8 @@
   make sure you don't set this for *nix guests; behavior may be
   unpredictable.
 
+- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
+  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
+  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
+
 <!-- End of code generated from the comments of the Config struct in builder/ebs/builder.go; -->


### PR DESCRIPTION
Fix CI failed in 3d9288d, as discussed in this https://github.com/hashicorp/packer-plugin-amazon/pull/99#issuecomment-871600961
