### PR TITLE
add license-specifications and placement/host-resource-group-arn

### DIFF
--- a/builder/common/run_config.hcl2spec.go
+++ b/builder/common/run_config.hcl2spec.go
@@ -35,6 +35,52 @@ func (*FlatAmiFilterOptions) HCL2Spec() map[string]hcldec.Spec {
 	return s
 }
 
+// FlatLicenseConfigurationRequest is an auto-generated flat version of LicenseConfigurationRequest.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatLicenseConfigurationRequest struct {
+	LicenseConfigurationArn *string `mapstructure:"license_configuration_arn" cty:"license_configuration_arn" hcl:"license_configuration_arn"`
+}
+
+// FlatMapstructure returns a new FlatLicenseConfigurationRequest.
+// FlatLicenseConfigurationRequest is an auto-generated flat version of LicenseConfigurationRequest.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*LicenseConfigurationRequest) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatLicenseConfigurationRequest)
+}
+
+// HCL2Spec returns the hcl spec of a LicenseConfigurationRequest.
+// This spec is used by HCL to read the fields of LicenseConfigurationRequest.
+// The decoded values from this spec will then be applied to a FlatLicenseConfigurationRequest.
+func (*FlatLicenseConfigurationRequest) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"license_configuration_arn": &hcldec.AttrSpec{Name: "license_configuration_arn", Type: cty.String, Required: false},
+	}
+	return s
+}
+
+// FlatLicenseSpecification is an auto-generated flat version of LicenseSpecification.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatLicenseSpecification struct {
+	LicenseConfigurationRequest *FlatLicenseConfigurationRequest `mapstructure:"license_configuration_request" cty:"license_configuration_request" hcl:"license_configuration_request"`
+}
+
+// FlatMapstructure returns a new FlatLicenseSpecification.
+// FlatLicenseSpecification is an auto-generated flat version of LicenseSpecification.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*LicenseSpecification) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatLicenseSpecification)
+}
+
+// HCL2Spec returns the hcl spec of a LicenseSpecification.
+// This spec is used by HCL to read the fields of LicenseSpecification.
+// The decoded values from this spec will then be applied to a FlatLicenseSpecification.
+func (*FlatLicenseSpecification) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"license_configuration_request": &hcldec.BlockSpec{TypeName: "license_configuration_request", Nested: hcldec.ObjectSpec((*FlatLicenseConfigurationRequest)(nil).HCL2Spec())},
+	}
+	return s
+}
+
 // FlatMetadataOptions is an auto-generated flat version of MetadataOptions.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatMetadataOptions struct {
@@ -58,6 +104,31 @@ func (*FlatMetadataOptions) HCL2Spec() map[string]hcldec.Spec {
 		"http_endpoint":               &hcldec.AttrSpec{Name: "http_endpoint", Type: cty.String, Required: false},
 		"http_tokens":                 &hcldec.AttrSpec{Name: "http_tokens", Type: cty.String, Required: false},
 		"http_put_response_hop_limit": &hcldec.AttrSpec{Name: "http_put_response_hop_limit", Type: cty.Number, Required: false},
+	}
+	return s
+}
+
+// FlatPlacement is an auto-generated flat version of Placement.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatPlacement struct {
+	HostResourceGroupArn *string `mapstructure:"host_resource_group_arn" required:"false" cty:"host_resource_group_arn" hcl:"host_resource_group_arn"`
+	Tenancy              *string `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
+}
+
+// FlatMapstructure returns a new FlatPlacement.
+// FlatPlacement is an auto-generated flat version of Placement.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*Placement) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatPlacement)
+}
+
+// HCL2Spec returns the hcl spec of a Placement.
+// This spec is used by HCL to read the fields of Placement.
+// The decoded values from this spec will then be applied to a FlatPlacement.
+func (*FlatPlacement) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"host_resource_group_arn": &hcldec.AttrSpec{Name: "host_resource_group_arn", Type: cty.String, Required: false},
+		"tenancy":                 &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -218,6 +218,16 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			NoEphemeral:                       b.config.NoEphemeral,
 		}
 	} else {
+		var tenancy string
+		tenancies := []string{b.config.Placement.Tenancy, b.config.Tenancy}
+
+		for i := range tenancies {
+			if tenancies[i] != "" {
+				tenancy = tenancies[i]
+				break
+			}
+		}
+
 		instanceStep = &awscommon.StepRunSourceInstance{
 			PollingConfig:                     b.config.PollingConfig,
 			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
@@ -236,7 +246,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
-			Tenancy:                           b.config.Tenancy,
+			LicenseSpecifications:             b.config.LicenseSpecifications,
+			HostResourceGroupArn:              b.config.Placement.HostResourceGroupArn,
+			Tenancy:                           tenancy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -87,6 +87,8 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                  `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	LicenseSpecifications                     []common.FlatLicenseSpecification      `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
+	Placement                                 *common.FlatPlacement                  `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -243,6 +245,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
+		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -245,6 +245,16 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			VolumeTags:                        b.config.VolumeRunTags,
 		}
 	} else {
+		var tenancy string
+		tenancies := []string{b.config.Placement.Tenancy, b.config.Tenancy}
+
+		for i := range tenancies {
+			if tenancies[i] != "" {
+				tenancy = tenancies[i]
+				break
+			}
+		}
+
 		instanceStep = &awscommon.StepRunSourceInstance{
 			PollingConfig:                     b.config.PollingConfig,
 			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
@@ -263,7 +273,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
-			Tenancy:                           b.config.Tenancy,
+			LicenseSpecifications:             b.config.LicenseSpecifications,
+			HostResourceGroupArn:              b.config.Placement.HostResourceGroupArn,
+			Tenancy:                           tenancy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -108,6 +108,8 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                  `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	LicenseSpecifications                     []common.FlatLicenseSpecification      `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
+	Placement                                 *common.FlatPlacement                  `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -264,6 +266,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
+		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -210,6 +210,16 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			VolumeTags:                        b.config.VolumeRunTags,
 		}
 	} else {
+		var tenancy string
+		tenancies := []string{b.config.Placement.Tenancy, b.config.Tenancy}
+
+		for i := range tenancies {
+			if tenancies[i] != "" {
+				tenancy = tenancies[i]
+				break
+			}
+		}
+
 		instanceStep = &awscommon.StepRunSourceInstance{
 			PollingConfig:                     b.config.PollingConfig,
 			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
@@ -228,7 +238,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
-			Tenancy:                           b.config.Tenancy,
+			LicenseSpecifications:             b.config.LicenseSpecifications,
+			HostResourceGroupArn:              b.config.Placement.HostResourceGroupArn,
+			Tenancy:                           tenancy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/ebsvolume/builder.hcl2spec.go
+++ b/builder/ebsvolume/builder.hcl2spec.go
@@ -120,6 +120,8 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                  `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	LicenseSpecifications                     []common.FlatLicenseSpecification      `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
+	Placement                                 *common.FlatPlacement                  `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -250,6 +252,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
+		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -279,6 +279,16 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			UserDataFile:             b.config.UserDataFile,
 		}
 	} else {
+		var tenancy string
+		tenancies := []string{b.config.Placement.Tenancy, b.config.Tenancy}
+
+		for i := range tenancies {
+			if tenancies[i] != "" {
+				tenancy = tenancies[i]
+				break
+			}
+		}
+
 		instanceStep = &awscommon.StepRunSourceInstance{
 			PollingConfig:            b.config.PollingConfig,
 			AssociatePublicIpAddress: b.config.AssociatePublicIpAddress,
@@ -292,7 +302,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			IsRestricted:             b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			SourceAMI:                b.config.SourceAmi,
 			Tags:                     b.config.RunTags,
-			Tenancy:                  b.config.Tenancy,
+			LicenseSpecifications:    b.config.LicenseSpecifications,
+			HostResourceGroupArn:     b.config.Placement.HostResourceGroupArn,
+			Tenancy:                  tenancy,
 			UserData:                 b.config.UserData,
 			UserDataFile:             b.config.UserDataFile,
 		}

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -87,6 +87,8 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                  `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	LicenseSpecifications                     []common.FlatLicenseSpecification      `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
+	Placement                                 *common.FlatPlacement                  `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 	TemporarySGSourceCidrs                    []string                               `mapstructure:"temporary_security_group_source_cidrs" required:"false" cty:"temporary_security_group_source_cidrs" hcl:"temporary_security_group_source_cidrs"`
 	UserData                                  *string                                `mapstructure:"user_data" required:"false" cty:"user_data" hcl:"user_data"`
@@ -247,6 +249,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
+		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 		"temporary_security_group_source_cidrs": &hcldec.AttrSpec{Name: "temporary_security_group_source_cidrs", Type: cty.List(cty.String), Required: false},
 		"user_data":                             &hcldec.AttrSpec{Name: "user_data", Type: cty.String, Required: false},

--- a/datasource/secretsmanager/data.go
+++ b/datasource/secretsmanager/data.go
@@ -125,7 +125,7 @@ func (d *Datasource) Execute() (cty.Value, error) {
 	output := DatasourceOutput{
 		Value:        value,
 		SecretString: aws.StringValue(secret.SecretString),
-		SecretBinary: fmt.Sprintf("%s", secret.SecretBinary),
+		SecretBinary: string(secret.SecretBinary),
 		VersionId:    versionId,
 	}
 	return hcl2helper.HCL2ValueFromConfig(output, d.OutputSpec()), nil

--- a/docs-partials/builder/common/LicenseConfigurationRequest-not-required.mdx
+++ b/docs-partials/builder/common/LicenseConfigurationRequest-not-required.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the LicenseConfigurationRequest struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `license_configuration_arn` (string) - The Amazon Resource Name (ARN) of the license configuration.
+
+<!-- End of code generated from the comments of the LicenseConfigurationRequest struct in builder/common/run_config.go; -->

--- a/docs-partials/builder/common/LicenseSpecification-not-required.mdx
+++ b/docs-partials/builder/common/LicenseSpecification-not-required.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the LicenseSpecification struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `license_configuration_request` (LicenseConfigurationRequest) - Describes a license configuration.
+
+<!-- End of code generated from the comments of the LicenseSpecification struct in builder/common/run_config.go; -->

--- a/docs-partials/builder/common/Placement-not-required.mdx
+++ b/docs-partials/builder/common/Placement-not-required.mdx
@@ -1,0 +1,11 @@
+<!-- Code generated from the comments of the Placement struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `host_resource_group_arn` (string) - The ARN of the host resource group in which to launch the instances.
+
+- `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
+  when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+  
+  The default is "default", meaning shared tenancy. Allowed values are "default",
+  "dedicated" and "host".
+
+<!-- End of code generated from the comments of the Placement struct in builder/common/run_config.go; -->

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -315,11 +315,75 @@
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
-- `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
-  when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+- `license_specifications` ([]LicenseSpecification) - The license configurations.
   
-  The default is "default", meaning shared tenancy. Allowed values are "default",
-  "dedicated" and "host".
+  HCL2 example:
+  ```hcl
+  source "amazon-ebs" "basic-example" {
+    license_specifications {
+      license_configuration_request = {
+        license_configuration_arn = "${var.license_configuration_arn}"
+      }
+    }
+  }
+  ```
+  
+  JSON example:
+  ```json
+  "builders" [
+    {
+      "type": "amazon-ebs",
+      "license_specifications": [
+        {
+          "license_configuration_request": {
+            "license_configuration_arn": "{{user `license_configuration_arn`}}"
+          }
+        }
+      ]
+    }
+  ]
+  ```
+  
+    Each `license_configuration_request` describes a license configuration,
+    the properties of which are:
+  
+    - `license_configuration_arn` (string) - The Amazon Resource Name (ARN)
+      of the license configuration.
+
+- `placement` (Placement) - Describes the placement of an instance.
+  
+  HCL2 example:
+  ```hcl
+  source "amazon-ebs" "basic-example" {
+    placement = {
+      host_resource_group_arn = "${var.host_resource_group_arn}"
+      tenancy                 = "${var.placement_tenancy}"
+    }
+  }
+  ```
+  
+  JSON example:
+  ```json
+  "builders" [
+    {
+      "type": "amazon-ebs",
+      "placement": {
+        "host_resource_group_arn": "{{user `host_resource_group_arn`}}",
+        "tenancy": "{{user `placement_tenancy`}}"
+      }
+    }
+  ]
+  ```
+  
+    - `host_resource_group_arn` (string) - The ARN of the host resource
+      group in which to launch the instances. If you specify a host
+      resource group ARN, omit the Tenancy parameter or set it to `host`.
+    - `tenancy` (string) - The tenancy of the instance (if the instance is
+      running in a VPC). An instance with a tenancy of `dedicated` runs on
+      single-tenant hardware. The default is `default`, meaning shared
+      tenancy. Allowed values are `default`, `dedicated` and `host`.
+
+- `tenancy` (string) - Deprecated: Use Placement Tenancy instead.
 
 - `temporary_security_group_source_cidrs` ([]string) - A list of IPv4 CIDR blocks to be authorized access to the instance, when
   packer is creating a temporary security group.


### PR DESCRIPTION
This PR adds support for scheduling instances to [host resource groups](https://docs.aws.amazon.com/license-manager/latest/userguide/host-resource-groups.html), which likewise requires the declaration of a [license configuration](https://docs.aws.amazon.com/license-manager/latest/userguide/license-configurations.html).

While the AWS SDK allows for a collection of license configurations, this PR flattens that to one in accordance with some of the other conventions observed. I'm open to changing that decision, updating the data model to more accurately reflect the collection of license configurations that comprise a license specification.

In all honesty I would prefer to group the `tenancy` and `host_resource_group_arn` settings under a `placement` grouping, but I wasn't sure what the policy was around backwards compatibility or the general attitude around adherence to the AWS SDK schema vs. flattening to provoke the end user to use simple variable names that they can override via `vars` arguments on the command line.

Any input is welcome. Thanks