### PR TITLE
Add a boot mode option to builders

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -193,6 +193,11 @@ type Config struct {
 	// what architecture to use when registering the final AMI; valid options
 	// are "x86_64" or "arm64". Defaults to "x86_64".
 	Architecture string `mapstructure:"ami_architecture" required:"false"`
+	// The boot mode. Valid options are `legacy-bios` and `uefi`. See the documentation on
+	// [boot modes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-boot.html) for
+	// more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
+	// `uefi` when `ami_architecture` is `arm64`.
+	BootMode string `mapstructure:"boot_mode" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -364,6 +369,19 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid ami_architecture values are "x86_64" and "arm64"`))
 	}
 
+	if b.config.BootMode != "" {
+		valid := false
+		for _, validBootMode := range []string{"legacy-bios", "uefi"} {
+			if validBootMode == b.config.BootMode {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid boot_mode values are "legacy-bios" and "uefi"`))
+		}
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}
@@ -482,6 +500,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			EnableAMIENASupport:      b.config.AMIENASupport,
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 			PollingConfig:            b.config.PollingConfig,
+			BootMode:                 b.config.BootMode,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,

--- a/builder/chroot/builder.hcl2spec.go
+++ b/builder/chroot/builder.hcl2spec.go
@@ -80,6 +80,7 @@ type FlatConfig struct {
 	RootVolumeEncryptBoot   *bool                             `mapstructure:"root_volume_encrypt_boot" required:"false" cty:"root_volume_encrypt_boot" hcl:"root_volume_encrypt_boot"`
 	RootVolumeKmsKeyId      *string                           `mapstructure:"root_volume_kms_key_id" required:"false" cty:"root_volume_kms_key_id" hcl:"root_volume_kms_key_id"`
 	Architecture            *string                           `mapstructure:"ami_architecture" required:"false" cty:"ami_architecture" hcl:"ami_architecture"`
+	BootMode                *string                           `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -162,6 +163,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"root_volume_encrypt_boot":      &hcldec.AttrSpec{Name: "root_volume_encrypt_boot", Type: cty.Bool, Required: false},
 		"root_volume_kms_key_id":        &hcldec.AttrSpec{Name: "root_volume_kms_key_id", Type: cty.String, Required: false},
 		"ami_architecture":              &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
+		"boot_mode":                     &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/chroot/step_register_ami.go
+++ b/builder/chroot/step_register_ami.go
@@ -20,6 +20,7 @@ type StepRegisterAMI struct {
 	EnableAMIENASupport      confighelper.Trilean
 	EnableAMISriovNetSupport bool
 	AMISkipBuildRegion       bool
+	BootMode                 string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -67,7 +68,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)
 	}
-
+	if s.BootMode != "" {
+		registerOpts.BootMode = aws.String(s.BootMode)
+	}
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
 	if err != nil {
 		state.Put("error", fmt.Errorf("Error registering AMI: %s", err))

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -196,6 +196,7 @@ type FlatConfig struct {
 	VolumeRunTags                             map[string]string                      `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
 	VolumeRunTag                              []config.FlatNameValue                 `mapstructure:"run_volume_tag" required:"false" cty:"run_volume_tag" hcl:"run_volume_tag"`
 	Architecture                              *string                                `mapstructure:"ami_architecture" required:"false" cty:"ami_architecture" hcl:"ami_architecture"`
+	BootMode                                  *string                                `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -349,6 +350,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"run_volume_tags":                       &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},
 		"run_volume_tag":                        &hcldec.BlockListSpec{TypeName: "run_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatNameValue)(nil).HCL2Spec())},
 		"ami_architecture":                      &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
+		"boot_mode":                             &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/ebssurrogate/step_register_ami.go
+++ b/builder/ebssurrogate/step_register_ami.go
@@ -25,6 +25,7 @@ type StepRegisterAMI struct {
 	image                    *ec2.Image
 	LaunchOmitMap            map[string]bool
 	AMISkipBuildRegion       bool
+	BootMode                 string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -71,6 +72,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 		// Set EnaSupport to true
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)
+	}
+	if s.BootMode != "" {
+		registerOpts.BootMode = aws.String(s.BootMode)
 	}
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
 	if err != nil {

--- a/docs-partials/builder/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/chroot/Config-not-required.mdx
@@ -153,4 +153,9 @@
 - `ami_architecture` (string) - what architecture to use when registering the final AMI; valid options
   are "x86_64" or "arm64". Defaults to "x86_64".
 
+- `boot_mode` (string) - The boot mode. Valid options are `legacy-bios` and `uefi`. See the documentation on
+  [boot modes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-boot.html) for
+  more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
+  `uefi` when `ami_architecture` is `arm64`.
+
 <!-- End of code generated from the comments of the Config struct in builder/chroot/builder.go; -->

--- a/docs-partials/builder/ebssurrogate/Config-not-required.mdx
+++ b/docs-partials/builder/ebssurrogate/Config-not-required.mdx
@@ -30,4 +30,9 @@
 - `ami_architecture` (string) - what architecture to use when registering the
   final AMI; valid options are "x86_64" or "arm64". Defaults to "x86_64".
 
+- `boot_mode` (string) - The boot mode. Valid options are `legacy-bios` and `uefi`. See the documentation on
+  [boot modes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ami-boot.html) for
+  more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
+  `uefi` when `ami_architecture` is `arm64`.
+
 <!-- End of code generated from the comments of the Config struct in builder/ebssurrogate/builder.go; -->


### PR DESCRIPTION
This enables passing an option `boot_mode` in the configurations for chroot and
ebssurrogate builders. This enables booting in `uefi` mode in addition to
`legacy-bios`.

The option is added only to the chroot and ebssurrogate builders because:
* The ebs builder uses the `CreateImage` API call, which inherits the boot mode
  from the source instance.
* The instance builder uses Amazon's AMI Tools, and per the EC2 user guide for
  creating instance store images, the command `ec2-bundle-vol` from AMI Tools
  does not bundle the /boot/efi directory if present, so it seems to be
  unsupported.
* The ebsvolume builder does not create an image so it is not needed.

If `boot_mode` is not defined in the configuration, the builders do not pass
a value for it to AWS, rather it is left unset so the default will be used. AWS
defaults to `legacy-bios` when the architecture is `x86_64` and `uefi` when the
architecture is `arm64`.

Closes #112

