### PR TITLE
enable aws debug logs

### DIFF
--- a/builder/common/access_config.go
+++ b/builder/common/access_config.go
@@ -340,7 +340,7 @@ func (c *AccessConfig) GetCredentials(config *aws.Config) (*awsCredentials.Crede
 		AssumeRoleTags:              c.AssumeRole.AssumeRoleTags,
 		AssumeRoleTransitiveTagKeys: c.AssumeRole.AssumeRoleTransitiveTagKeys,
 		CredsFilename:               c.CredsFilename,
-		DebugLogging:                false,
+		DebugLogging:                c.packerConfig.PackerDebug,
 		// TODO: implement for Packer
 		// IamEndpoint:                 c.Endpoints["iam"],
 		Insecure:             c.InsecureSkipTLSVerify,


### PR DESCRIPTION
Hi there,

**Description**
Packer handles [debug flag](https://www.packer.io/docs/debugging) that should help developers to figure out where is the problem.
By some reason we don't propagate this flag to [awsbase.Config](https://github.com/hashicorp/packer-plugin-amazon/blob/main/builder/common/access_config.go#L343)`. It could hides some important logs.

**Story**
 For example, today I had a problem I tried to assume a role with pretty small duration time(60 seconds), but AWS [doesn't support](https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html#options) so small value(min value is 900 seconds) and raises an exception in this case like this:
```
Role (arn:aws:iam::ACCOUNT:ROLE) cannot be assumed.

There are a number of possible causes of this - the most common are:
  * The credentials used in order to assume the role are invalid
  * The credentials do not have appropriate permission to assume the role
  * The role ARN is not valid

Error: NoCredentialProviders: no valid providers in chain. Deprecated.
  For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

As you can see there are no any information about what is the problem.

To see logs we should turn on DebugLogging flag. This flag enables [additional aws logs](https://github.com/hashicorp/aws-sdk-go-base/search?q=DebugLogging).

In my case I saw these additional log records:
```
go_build_github_com_hashicorp_packer plugin: [DEBUG] [aws-sdk-go] DEBUG: Validate Request sts/AssumeRole failed, not retrying, error InvalidParameter: 1 validation error(s) found.
[INFO] (telemetry) ending amazon-ebs
go_build_github_com_hashicorp_packer plugin: - minimum field value of 900, AssumeRoleInput.DurationSeconds.
go_build_github_com_hashicorp_packer plugin: [DEBUG] [aws-sdk-go] DEBUG: Build Request sts/AssumeRole failed, not retrying, error InvalidParameter: 1 validation error(s) found.
go_build_github_com_hashicorp_packer plugin: - minimum field value of 900, AssumeRoleInput.DurationSeconds.
go_build_github_com_hashicorp_packer plugin: [DEBUG] [aws-sdk-go] DEBUG: Sign Request sts/AssumeRole failed, not retrying, error InvalidParameter: 1 validation error(s) found.
go_build_github_com_hashicorp_packer plugin: - minimum field value of 900, AssumeRoleInput.DurationSeconds.
```
These lines helped me a lot to figure out where is the problem.

Can you please take a look on my PR? I hope that this small fix will save a lot of time for others.

**Similar issues:**
Maybe we should apply similar fix for this [repo](https://github.com/hashicorp/packer-plugin-docker/blob/f0ae490e369c5205e1de838e6536bb2371287d6d/builder/docker/ecr_login.go#L127) too?

Best