### PR TITLE
add SourceAMI to PARtifact

### DIFF
--- a/builder/common/artifact.go
+++ b/builder/common/artifact.go
@@ -165,9 +165,8 @@ func (a *Artifact) stateHCPPackerRegistryMetadata() interface{} {
 	}
 
 	for _, image := range images {
-		image.Labels = map[string]string{
-			"source_image": data["SourceAMIName"].(string),
-		}
+		image.SourceImageID = data["SourceAMI"].(string)
 	}
+
 	return images
 }

--- a/builder/common/artifact_test.go
+++ b/builder/common/artifact_test.go
@@ -96,6 +96,7 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 		Amis: map[string]string{
 			"east": "foo", "west": "bar",
 		},
+		StateData: map[string]interface{}{"generated_data": map[string]interface{}{"SourceAMI": "ami-12345"}},
 	}
 
 	result := artifact.State(registryimage.ArtifactStateURI)
@@ -118,11 +119,13 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 			ImageID:        "foo",
 			ProviderName:   "aws",
 			ProviderRegion: "east",
+			SourceImageID:  "ami-12345",
 		},
 		{
 			ImageID:        "bar",
 			ProviderName:   "aws",
 			ProviderRegion: "west",
+			SourceImageID:  "ami-12345",
 		},
 	}
 	if !reflect.DeepEqual(images, expected) {

--- a/builder/ebsvolume/artifact.go
+++ b/builder/ebsvolume/artifact.go
@@ -151,9 +151,7 @@ func (a *Artifact) stateHCPPackerRegistryMetadata() interface{} {
 	}
 
 	for _, image := range images {
-		image.Labels = map[string]string{
-			"source_image": data["SourceAMIName"].(string),
-		}
+		image.SourceImageID = data["SourceAMI"].(string)
 	}
 
 	return images

--- a/builder/ebsvolume/artifact_test.go
+++ b/builder/ebsvolume/artifact_test.go
@@ -44,6 +44,7 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 	artifact := &Artifact{
 		Volumes:   volumes,
 		Snapshots: snapshots,
+		StateData: map[string]interface{}{"generated_data": map[string]interface{}{"SourceAMI": "ami-12345"}},
 	}
 
 	result := artifact.State(registryimage.ArtifactStateURI)
@@ -66,21 +67,25 @@ func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 			ImageID:        "vol-4567",
 			ProviderName:   "aws",
 			ProviderRegion: "west",
+			SourceImageID:  "ami-12345",
 		},
 		{
 			ImageID:        "vol-0987",
 			ProviderName:   "aws",
 			ProviderRegion: "west",
+			SourceImageID:  "ami-12345",
 		},
 		{
 			ImageID:        "snap-4567",
 			ProviderName:   "aws",
 			ProviderRegion: "west",
+			SourceImageID:  "ami-12345",
 		},
 		{
 			ImageID:        "snap-0987",
 			ProviderName:   "aws",
 			ProviderRegion: "west",
+			SourceImageID:  "ami-12345",
 		},
 	}
 	if !reflect.DeepEqual(images, expected) {

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,9 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/hcl/v2 v2.10.1
-	github.com/hashicorp/packer-plugin-sdk v0.2.5
+	github.com/hashicorp/packer-plugin-sdk v0.2.6
 	github.com/hashicorp/vault/api v1.1.1
+	github.com/mitchellh/mapstructure v1.4.1
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.9.1
 	golang.org/x/sys v0.0.0-20210831042530-f4d43177bf5e
@@ -65,7 +66,6 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/iochan v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.0 // indirect
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/packer-community/winrmcp v0.0.0-20180921211025-c76d91c1e7db // indirect

--- a/go.sum
+++ b/go.sum
@@ -350,8 +350,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.1/go.mod h1:4gW7WsVCke5TE7EPeYliwHlRUyBtfCwuFwuMg2DmyNY=
 github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC7AO2g=
 github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
-github.com/hashicorp/packer-plugin-sdk v0.2.5 h1:qydxm7rbyUuUvvh2rxTZjur8kG5JQNGtpOifS4Xv1BY=
-github.com/hashicorp/packer-plugin-sdk v0.2.5/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
+github.com/hashicorp/packer-plugin-sdk v0.2.6 h1:/v6NODvwDC5XKbF/A6/WQrRmUoPLy70Uu+IGSSklfOc=
+github.com/hashicorp/packer-plugin-sdk v0.2.6/go.mod h1:ii9ub5UNAp30RGod3i3W8qj7wA+H7kpURnD+Jt7oDkQ=
 github.com/hashicorp/serf v0.9.5 h1:EBWvyu9tcRszt3Bxp3KNssBMP1KuHWyO51lz9+786iM=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f/go.mod h1:euTFbi2YJgwcju3imEt919lhJKF68nN1cQPq3aA+kBE=


### PR DESCRIPTION
Adds SourceAMI to the PARtifact, so that hcp packer registry can track image ancestry. 


