### PR TITLE
Fix `deprecate_at` when copying to additional regions

### DIFF
--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -352,6 +352,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			IsRestricted:       b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			Tags:               b.config.RunTags,
 		},
+		&stepEnableDeprecation{
+			DeprecationTime: b.config.DeprecationTime,
+		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:       &b.config.AccessConfig,
 			Regions:            b.config.AMIRegions,
@@ -379,9 +382,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Tags:               b.config.AMITags,
 			SnapshotTags:       b.config.SnapshotTags,
 			Ctx:                b.config.ctx,
-		},
-		&stepEnableDeprecation{
-			DeprecationTime: b.config.DeprecationTime,
 		},
 	}
 


### PR DESCRIPTION
This PR changes the order that PackerConfig is constructed for the Runner.

It moves  `stepEnableDeprecation` after the AMI is created, this allows the Deprecation Time to be successfully applied to AMIs when copying to multiple regions.

An example configuration is in the issue 

Closes #137 

