### PR TITLE
[125]: Invalid KMS key error for multi-region keys

### DIFF
--- a/builder/common/ami_config.go
+++ b/builder/common/ami_config.go
@@ -277,7 +277,7 @@ func (c *AMIConfig) prepareRegions(accessConfig *AccessConfig) (errs []error) {
 
 // See https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html
 func ValidateKmsKey(kmsKey string) (valid bool) {
-	kmsKeyIdPattern := `[a-fmrk0-9-]+$`
+	kmsKeyIdPattern := `(:?mrk-)?[a-f0-9]+-[a-f0-9-]+$`
 	aliasPattern := `alias/[a-zA-Z0-9:/_-]+$`
 	kmsArnStartPattern := `^arn:aws(-us-gov)?:kms:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12}):`
 	if regexp.MustCompile(fmt.Sprintf("^%s", kmsKeyIdPattern)).MatchString(kmsKey) {

--- a/builder/common/ami_config_test.go
+++ b/builder/common/ami_config_test.go
@@ -197,6 +197,8 @@ func TestAMIConfigPrepare_ValidateKmsKey(t *testing.T) {
 		"ghij1234+e567_890f-a12b-a123b4cd56ef",
 		"foo/bar",
 		"arn:aws:kms:us-east-1:012345678910:foo/bar",
+		"arn:aws:kms:us-east-1:012345678910:key/zab-12345678-1234-abcd-0000-123456789012",
+		"arn:aws:kms:us-east-1:012345678910:key/mkr-12345678-1234-abcd-0000-123456789012",
 		"arn:foo:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef",
 	}
 	for _, invalidCase := range invalidCases {


### PR DESCRIPTION
Why do we need this change?
=======================
Amazon has updated how they generate keys to include for multi region
keys a mrk prefix to the actual name. Without including matchers for the
mrk characters keys will fail to match

What effects does this change have?
=======================
* Adds mkr to the list of approved characters that match the regex

Closes #125