### PR TITLE
add missing i386 and x86_64_mac architectures

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -191,7 +191,7 @@ type Config struct {
 	// prefix `kms_key_id` with `alias/`.
 	RootVolumeKmsKeyId string `mapstructure:"root_volume_kms_key_id" required:"false"`
 	// what architecture to use when registering the final AMI; valid options
-	// are "x86_64" or "arm64". Defaults to "x86_64".
+	// are "arm64", "i386", "x86_64", or "x86_64_mac". Defaults to "x86_64".
 	Architecture string `mapstructure:"ami_architecture" required:"false"`
 
 	ctx interpolate.Context
@@ -354,14 +354,14 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	}
 	valid := false
-	for _, validArch := range []string{"x86_64", "arm64"} {
+	for _, validArch := range []string{"arm64", "i386", "x86_64", "x86_64_mac"} {
 		if validArch == b.config.Architecture {
 			valid = true
 			break
 		}
 	}
 	if !valid {
-		errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid ami_architecture values are "x86_64" and "arm64"`))
+		errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid ami_architecture values are "arm64", "i386", "x86_64", or "x86_64_mac"`))
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -67,8 +67,8 @@ type Config struct {
 	// [`dynamic_block`](https://packer.io/docs/templates/hcl_templates/expressions.html#dynamic-blocks)
 	// will allow you to create those programatically.
 	VolumeRunTag config.NameValues `mapstructure:"run_volume_tag" required:"false"`
-	// what architecture to use when registering the
-	// final AMI; valid options are "x86_64" or "arm64". Defaults to "x86_64".
+	// what architecture to use when registering the final AMI; valid options
+	// are "arm64", "i386", "x86_64", or "x86_64_mac". Defaults to "x86_64".
 	Architecture string `mapstructure:"ami_architecture" required:"false"`
 
 	ctx interpolate.Context
@@ -156,14 +156,14 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		b.config.Architecture = "x86_64"
 	}
 	valid := false
-	for _, validArch := range []string{"x86_64", "arm64"} {
+	for _, validArch := range []string{"arm64", "i386", "x86_64", "x86_64_mac"} {
 		if validArch == b.config.Architecture {
 			valid = true
 			break
 		}
 	}
 	if !valid {
-		errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid ami_architecture values are "x86_64" and "arm64"`))
+		errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid ami_architecture values are "arm64", "i386", "x86_64", or "x86_64_mac"`))
 	}
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs

--- a/docs-partials/builder/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/chroot/Config-not-required.mdx
@@ -151,6 +151,6 @@
   prefix `kms_key_id` with `alias/`.
 
 - `ami_architecture` (string) - what architecture to use when registering the final AMI; valid options
-  are "x86_64" or "arm64". Defaults to "x86_64".
+  are "arm64", "i386", "x86_64", or "x86_64_mac". Defaults to "x86_64".
 
 <!-- End of code generated from the comments of the Config struct in builder/chroot/builder.go; -->

--- a/docs-partials/builder/ebssurrogate/Config-not-required.mdx
+++ b/docs-partials/builder/ebssurrogate/Config-not-required.mdx
@@ -27,7 +27,7 @@
   [`dynamic_block`](https://packer.io/docs/templates/hcl_templates/expressions.html#dynamic-blocks)
   will allow you to create those programatically.
 
-- `ami_architecture` (string) - what architecture to use when registering the
-  final AMI; valid options are "x86_64" or "arm64". Defaults to "x86_64".
+- `ami_architecture` (string) - what architecture to use when registering the final AMI; valid options
+  are "arm64", "i386", "x86_64", or "x86_64_mac". Defaults to "x86_64".
 
 <!-- End of code generated from the comments of the Config struct in builder/ebssurrogate/builder.go; -->


### PR DESCRIPTION
Add support for i386 and x86_64_mac architectures to `amazon-chroot` and `amazon-ebssurrogate` builders.

Closes #153