### PR TITLE
Import post processor: Allow creation of AMIs with uefi boot & graviton support 

### DIFF
--- a/docs/post-processors/import.mdx
+++ b/docs/post-processors/import.mdx
@@ -112,6 +112,13 @@ Optional:
 	launch the resulting AMI(s). By default no organizational units have permission to launch
 	the AMI.
 
+- `architecture` (string) - The architecture of the resultant AMI. One of:
+  `i386`, `x86_64`, or `arm64`. Defaults to `x86_64`.
+
+- `boot_mode` (string) - The supported boot mode of the resultant AMI. One of:
+  `legacy-bios` or `uefi`. If `architecture` is set to `arm64` then this value
+  must be set to  `uefi`.
+
 - `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
   provider whose API is compatible with aws EC2. Specify another endpoint
   like this `https://ec2.custom.endpoint.com`.

--- a/post-processor/import/post-processor.hcl2spec.go
+++ b/post-processor/import/post-processor.hcl2spec.go
@@ -52,6 +52,8 @@ type FlatConfig struct {
 	LicenseType           *string                           `mapstructure:"license_type" cty:"license_type" hcl:"license_type"`
 	RoleName              *string                           `mapstructure:"role_name" cty:"role_name" hcl:"role_name"`
 	Format                *string                           `mapstructure:"format" cty:"format" hcl:"format"`
+	Architecture          *string                           `mapstructure:"architecture" cty:"architecture" hcl:"architecture"`
+	BootMode              *string                           `mapstructure:"boot_mode" cty:"boot_mode" hcl:"boot_mode"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -107,6 +109,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"license_type":                  &hcldec.AttrSpec{Name: "license_type", Type: cty.String, Required: false},
 		"role_name":                     &hcldec.AttrSpec{Name: "role_name", Type: cty.String, Required: false},
 		"format":                        &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
+		"architecture":                  &hcldec.AttrSpec{Name: "architecture", Type: cty.String, Required: false},
+		"boot_mode":                     &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
This PR allows creation of [UEFI based](https://aws.amazon.com/about-aws/whats-new/2021/03/amazon-ec2-now-supports-uefi-boot-when-migrating-virtual-machines-to-ec2/) amis as well arm64/graviton based AMIs
