### PR TITLE
Parses filter option values as csv strings

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -140,7 +140,8 @@ type Config struct {
 	//This will fail unless *exactly* one AMI is returned. In the above example,
 	//`most_recent` will cause this to succeed by selecting the newest image.
 	//
-	//-   `filters` (map of strings) - filters used to select a `source_ami`.
+	//-   `filters` (map{key string, value string | comma separated string}) -
+	//  filters used to select a `source_ami`.
 	//	NOTE: This will fail unless *exactly* one AMI is returned. Any filter
 	//	described in the docs for
 	//	[DescribeImages](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html)

--- a/builder/common/build_filter.go
+++ b/builder/common/build_filter.go
@@ -24,7 +24,8 @@ func buildEc2Filters(input map[string]string) []*ec2.Filter {
 		}
 
 		for _, r := range values {
-			b = append(b, &r)
+			var value = r
+			b = append(b, &value)
 		}
 
 		filters = append(filters, &ec2.Filter{

--- a/builder/common/build_filter.go
+++ b/builder/common/build_filter.go
@@ -1,18 +1,35 @@
 package common
 
 import (
+	"encoding/csv"
+	"log"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 // Build a slice of EC2 (AMI/Subnet/VPC) filter options from the filters provided.
 func buildEc2Filters(input map[string]string) []*ec2.Filter {
 	var filters []*ec2.Filter
+
 	for k, v := range input {
+		var b []*string
+
 		a := k
-		b := v
+		csvReader := csv.NewReader(strings.NewReader(v))
+
+		values, err := csvReader.Read()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for _, r := range values {
+			b = append(b, &r)
+		}
+
 		filters = append(filters, &ec2.Filter{
 			Name:   &a,
-			Values: []*string{&b},
+			Values: b,
 		})
 	}
 	return filters

--- a/builder/common/build_filter.go
+++ b/builder/common/build_filter.go
@@ -17,6 +17,7 @@ func buildEc2Filters(input map[string]string) []*ec2.Filter {
 
 		a := k
 		csvReader := csv.NewReader(strings.NewReader(v))
+		csvReader.TrimLeadingSpace = true
 
 		values, err := csvReader.Read()
 		if err != nil {

--- a/builder/common/build_filter_test.go
+++ b/builder/common/build_filter_test.go
@@ -1,24 +1,83 @@
 package common
 
 import (
+	"strings"
 	"testing"
 )
 
-func TestStepSourceAmiInfo_BuildFilter(t *testing.T) {
+func TestStepSourceAmiInfo_BuildFilter_SingleValue(t *testing.T) {
 	filter_key := "name"
 	filter_value := "foo"
 	filter_key2 := "name2"
-	filter_value2 := "foo2"
+	filter_value2 := " foo2"
+	filter_key3 := "name3"
+	filter_value3 := "foo3 "
 
-	inputFilter := map[string]string{filter_key: filter_value, filter_key2: filter_value2}
+	inputFilter := map[string]string{
+		filter_key:  filter_value,
+		filter_key2: filter_value2,
+		filter_key3: filter_value3,
+	}
+
 	outputFilter := buildEc2Filters(inputFilter)
+
+	testFilter := map[string]string{
+		filter_key:  filter_value,
+		filter_key2: strings.TrimSpace(filter_value2),
+		filter_key3: filter_value3,
+	}
 
 	// deconstruct filter back into things we can test
 	foundMap := map[string]bool{filter_key: false, filter_key2: false}
 	for _, filter := range outputFilter {
-		for key, value := range inputFilter {
+		for key, value := range testFilter {
 			if *filter.Name == key && *filter.Values[0] == value {
 				foundMap[key] = true
+			}
+		}
+	}
+
+	for k, v := range foundMap {
+		if !v {
+			t.Fatalf("Fail: should have found value for key: %s", k)
+		}
+	}
+}
+
+func TestStepSourceAmiInfo_BuildFilter_ListValue(t *testing.T) {
+	filter_key := "name-no-space-between-comma"
+	filter_value := "foo1-1,foo1-2,foo1-3"
+	filter_key2 := "name-space-between-comma"
+	filter_value2 := "foo2-1, foo2-2, foo2-3"
+	filter_key3 := "name-embedded-comma-and-leading-space"
+	filter_value3 := "\"foo3-1, with comma\",foo3-2 without comma, \" foo3-3\""
+
+	inputFilter := map[string]string{
+		filter_key:  filter_value,
+		filter_key2: filter_value2,
+		filter_key3: filter_value3,
+	}
+
+	outputFilter := buildEc2Filters(inputFilter)
+
+	testFilter := map[string][]string{
+		filter_key:  {"foo1", "foo1-2", "foo1-3"},
+		filter_key2: {"foo2-1", "foo2-2", "foo2-3"},
+		filter_key3: {"foo3-1, with comma", "foo3-2 without comma", " foo3-3"},
+	}
+
+	// deconstruct filter back into things we can test
+	foundMap := map[string]bool{filter_key: false, filter_key2: false}
+	for _, filter := range outputFilter {
+		for key, value := range testFilter {
+			if *filter.Name == key {
+				for idx, filter_value := range value {
+					if *filter.Values[idx] == filter_value {
+						foundMap[key] = true
+					} else {
+						foundMap[key] = false
+					}
+				}
 			}
 		}
 	}

--- a/docs-partials/builder/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/chroot/Config-not-required.mdx
@@ -100,7 +100,8 @@
   This will fail unless *exactly* one AMI is returned. In the above example,
   `most_recent` will cause this to succeed by selecting the newest image.
   
-  -   `filters` (map of strings) - filters used to select a `source_ami`.
+  -   `filters` (map{key string, value string | comma separated string}) -
+   filters used to select a `source_ami`.
   	NOTE: This will fail unless *exactly* one AMI is returned. Any filter
   	described in the docs for
   	[DescribeImages](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html)


### PR DESCRIPTION
Currently, EC2 filter values are treated as a single string item. However, to the AWS API, they are lists of strings. `buildEc2Filters` creates the struct expected by the API, but does not handle the case where the user wants to pass several values for the filter option.

This patch parses the filter option values as csv strings, to maintain backwards compatibility with the current interface while allowing users to pass a multi-valued argument.

Closes #13 
