### PR TITLE
Docs update: add note for block_duration_minutes

### DIFF
--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -93,7 +93,9 @@ type RunConfig struct {
 	// required duration for the Spot Instances (also known as Spot blocks). This
 	// value must be a multiple of 60 (60, 120, 180, 240, 300, or 360). You can't
 	// specify an Availability Zone group or a launch group if you specify a
-	// duration.
+	// duration. Note: This parameter is no longer available to new customers
+	// from July 1, 2021. [See Amazon's
+	//documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances).
 	BlockDurationMinutes int64 `mapstructure:"block_duration_minutes" required:"false"`
 	// Packer normally stops the build instance after all provisioners have
 	// run. For Windows instances, it is sometimes desirable to [run

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -11,7 +11,9 @@
   required duration for the Spot Instances (also known as Spot blocks). This
   value must be a multiple of 60 (60, 120, 180, 240, 300, or 360). You can't
   specify an Availability Zone group or a launch group if you specify a
-  duration.
+  duration. Note: This parameter is no longer available to new customers
+  from July 1, 2021. [See Amazon's
+  documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-requests.html#fixed-duration-spot-instances).
 
 - `disable_stop_instance` (bool) - Packer normally stops the build instance after all provisioners have
   run. For Windows instances, it is sometimes desirable to [run


### PR DESCRIPTION
Hi, this updates the documentation for the parameter (ebs#block_duration_minutes) so everyone is aware of the it's deprecation to new customers.

Please do suggest changes to the way it's phrased if you think it can be improved.

Closes #176 