### PR TITLE
Add Unit test for KeyPair step

### DIFF
--- a/builder/common/step_key_pair.go
+++ b/builder/common/step_key_pair.go
@@ -14,6 +14,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/retry"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 type StepKeyPair struct {
@@ -69,7 +70,7 @@ func (s *StepKeyPair) Run(ctx context.Context, state multistep.StateBag) multist
 
 	if !s.IsRestricted {
 		region := state.Get("region").(*string)
-		ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, region, state)
+		ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, aws.StringValue(region), state)
 		if err != nil {
 			err := fmt.Errorf("Error tagging key pair: %s", err)
 			state.Put("error", err)

--- a/builder/common/step_key_pair.go
+++ b/builder/common/step_key_pair.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -14,7 +15,6 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/retry"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
-	"github.com/aws/aws-sdk-go/aws"
 )
 
 type StepKeyPair struct {

--- a/builder/common/step_key_pair.go
+++ b/builder/common/step_key_pair.go
@@ -68,7 +68,7 @@ func (s *StepKeyPair) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 
 	if !s.IsRestricted {
-		region := state.Get("region").(string)
+		region := state.Get("region").(*string)
 		ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, region, state)
 		if err != nil {
 			err := fmt.Errorf("Error tagging key pair: %s", err)

--- a/builder/common/step_key_pair.go
+++ b/builder/common/step_key_pair.go
@@ -68,7 +68,7 @@ func (s *StepKeyPair) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 
 	if !s.IsRestricted {
-        region := state.Get("region").(string)
+		region := state.Get("region").(string)
 		ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, region, state)
 		if err != nil {
 			err := fmt.Errorf("Error tagging key pair: %s", err)

--- a/builder/common/step_key_pair.go
+++ b/builder/common/step_key_pair.go
@@ -68,7 +68,8 @@ func (s *StepKeyPair) Run(ctx context.Context, state multistep.StateBag) multist
 	}
 
 	if !s.IsRestricted {
-		ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, *ec2conn.Config.Region, state)
+        region := state.Get("region").(string)
+		ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, region, state)
 		if err != nil {
 			err := fmt.Errorf("Error tagging key pair: %s", err)
 			state.Put("error", err)

--- a/builder/common/step_key_pair.go
+++ b/builder/common/step_key_pair.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -58,7 +59,7 @@ func (s *StepKeyPair) Run(ctx context.Context, state multistep.StateBag) multist
 		return multistep.ActionContinue
 	}
 
-	ec2conn := state.Get("ec2").(*ec2.EC2)
+	ec2conn := state.Get("ec2").(ec2iface.EC2API)
 	var keyResp *ec2.CreateKeyPairOutput
 
 	ui.Say(fmt.Sprintf("Creating temporary keypair: %s", s.Comm.SSHTemporaryKeyPairName))

--- a/builder/common/step_key_pair_test.go
+++ b/builder/common/step_key_pair_test.go
@@ -19,7 +19,6 @@ type mockEC2KeyPairConn struct {
 
 	CreateKeyPairCount int
 	CreateKeyPairArgs  []ec2.CreateKeyPairInput
-	waitCount          int
 
 	lock sync.Mutex
 }

--- a/builder/common/step_key_pair_test.go
+++ b/builder/common/step_key_pair_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-    "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"

--- a/builder/common/step_key_pair_test.go
+++ b/builder/common/step_key_pair_test.go
@@ -9,17 +9,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	"github.com/hashicorp/packer-plugin-sdk/communicator"
 )
 
 type mockEC2KeyPairConn struct {
 	ec2iface.EC2API
 
-	CreateKeyPairCount   int
-	CreateKeyPairArgs    []ec2.CreateKeyPairInput
-	waitCount            int
+	CreateKeyPairCount int
+	CreateKeyPairArgs  []ec2.CreateKeyPairInput
+	waitCount          int
 
 	lock sync.Mutex
 }
@@ -27,16 +27,16 @@ type mockEC2KeyPairConn struct {
 func (m *mockEC2KeyPairConn) CreateKeyPair(keyPairInput *ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error) {
 	m.lock.Lock()
 	m.CreateKeyPairCount++
-        m.CreateKeyPairArgs = append(m.CreateKeyPairArgs, *keyPairInput)
+	m.CreateKeyPairArgs = append(m.CreateKeyPairArgs, *keyPairInput)
 	m.lock.Unlock()
-        keyMaterial := "I'm a cool key"
+	keyMaterial := "I'm a cool key"
 	output := &ec2.CreateKeyPairOutput{
-           KeyMaterial:  &keyMaterial,
+		KeyMaterial: &keyMaterial,
 	}
 	return output, nil
 }
 
-func getKeyPairMockConn() (ec2iface.EC2API) {
+func getKeyPairMockConn() ec2iface.EC2API {
 	return &mockEC2KeyPairConn{}
 }
 
@@ -57,14 +57,14 @@ func TestStepKeyPair_callsCreateKeyPairOnceWithName(t *testing.T) {
 	//testSSHTemporaryKeyPair := communicator.SSHTemporaryKeyPair{SSHTemporaryKeyPairType: "rsa"}
 	testSSH := communicator.SSH{
 		SSHTemporaryKeyPairName: "temp-key-name",
-		//SSHTemporaryKeyPair: testSSHTemporaryKeyPair, 
+		//SSHTemporaryKeyPair: testSSHTemporaryKeyPair,
 	}
 	comm := communicator.Config{
 		SSH: testSSH,
 	}
-	stepKeyPair := StepKeyPair {
-	    Debug: false,
-		Comm: &comm,
+	stepKeyPair := StepKeyPair{
+		Debug: false,
+		Comm:  &comm,
 	}
 
 	state := keyPairState()
@@ -72,14 +72,14 @@ func TestStepKeyPair_callsCreateKeyPairOnceWithName(t *testing.T) {
 	createKeyPairCallCount := state.Get("ec2").(*mockEC2KeyPairConn).CreateKeyPairCount
 	createKeyPairArgs := state.Get("ec2").(*mockEC2KeyPairConn).CreateKeyPairArgs
 	if createKeyPairCallCount != 1 {
-	   t.Fatalf(fmt.Sprintf("Expected CreateKeyPair to be called %d times, was called %d times", 1, createKeyPairCallCount))
+		t.Fatalf(fmt.Sprintf("Expected CreateKeyPair to be called %d times, was called %d times", 1, createKeyPairCallCount))
 	}
-	if *createKeyPairArgs[0].KeyName != "temp-key-name"{
-	   t.Fatalf(fmt.Sprintf("Unexpected Key Type expected %s, got %s" , "temp-key-name" , *createKeyPairArgs[0].KeyName))
+	if *createKeyPairArgs[0].KeyName != "temp-key-name" {
+		t.Fatalf(fmt.Sprintf("Unexpected Key Type expected %s, got %s", "temp-key-name", *createKeyPairArgs[0].KeyName))
 	}
 	// This case will pass when key type issue is fixed
 	//
-        //if *createKeyPairArgs[0].KeyType != "rsa" {
-	  // t.Fatalf(fmt.Sprintf("Expeccted KeyType %s got %s", "rsa", *createKeyPairArgs[0].KeyType))
+	//if *createKeyPairArgs[0].KeyType != "rsa" {
+	// t.Fatalf(fmt.Sprintf("Expeccted KeyType %s got %s", "rsa", *createKeyPairArgs[0].KeyType))
 	//}
 }

--- a/builder/common/step_key_pair_test.go
+++ b/builder/common/step_key_pair_test.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/communicator"
+)
+
+type mockEC2KeyPairConn struct {
+	ec2iface.EC2API
+
+	CreateKeyPairCount   int
+	CreateKeyPairArgs    []ec2.CreateKeyPairInput
+	waitCount            int
+
+	lock sync.Mutex
+}
+
+func (m *mockEC2KeyPairConn) CreateKeyPair(keyPairInput *ec2.CreateKeyPairInput) (*ec2.CreateKeyPairOutput, error) {
+	m.lock.Lock()
+	m.CreateKeyPairCount++
+        m.CreateKeyPairArgs = append(m.CreateKeyPairArgs, *keyPairInput)
+	m.lock.Unlock()
+        keyMaterial := "I'm a cool key"
+	output := &ec2.CreateKeyPairOutput{
+           KeyMaterial:  &keyMaterial,
+	}
+	return output, nil
+}
+
+func getKeyPairMockConn() (ec2iface.EC2API) {
+	return &mockEC2KeyPairConn{}
+}
+
+func keyPairState() multistep.StateBag {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", &packersdk.BasicUi{
+		Reader: new(bytes.Buffer),
+		Writer: new(bytes.Buffer),
+	})
+	conn := getKeyPairMockConn()
+	state.Put("ec2", conn)
+	state.Put("region", "us-east-1")
+	return state
+}
+
+//Add "AndType" to the name of this test
+func TestStepKeyPair_callsCreateKeyPairOnceWithName(t *testing.T) {
+	//testSSHTemporaryKeyPair := communicator.SSHTemporaryKeyPair{SSHTemporaryKeyPairType: "rsa"}
+	testSSH := communicator.SSH{
+		SSHTemporaryKeyPairName: "temp-key-name",
+		//SSHTemporaryKeyPair: testSSHTemporaryKeyPair, 
+	}
+	comm := communicator.Config{
+		SSH: testSSH,
+	}
+	stepKeyPair := StepKeyPair {
+	    Debug: false,
+		Comm: &comm,
+	}
+
+	state := keyPairState()
+	stepKeyPair.Run(context.Background(), state)
+	createKeyPairCallCount := state.Get("ec2").(*mockEC2KeyPairConn).CreateKeyPairCount
+	createKeyPairArgs := state.Get("ec2").(*mockEC2KeyPairConn).CreateKeyPairArgs
+	if createKeyPairCallCount != 1 {
+	   t.Fatalf(fmt.Sprintf("Expected CreateKeyPair to be called %d times, was called %d times", 1, createKeyPairCallCount))
+	}
+	if *createKeyPairArgs[0].KeyName != "temp-key-name"{
+	   t.Fatalf(fmt.Sprintf("Unexpected Key Type expected %s, got %s" , "temp-key-name" , *createKeyPairArgs[0].KeyName))
+	}
+	// This case will pass when key type issue is fixed
+	//
+        //if *createKeyPairArgs[0].KeyType != "rsa" {
+	  // t.Fatalf(fmt.Sprintf("Expeccted KeyType %s got %s", "rsa", *createKeyPairArgs[0].KeyType))
+	//}
+}

--- a/builder/common/step_key_pair_test.go
+++ b/builder/common/step_key_pair_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 
+    "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -47,7 +48,7 @@ func keyPairState() multistep.StateBag {
 	})
 	conn := getKeyPairMockConn()
 	state.Put("ec2", conn)
-	state.Put("region", "us-east-1")
+	state.Put("region", aws.String("us-east-1"))
 	return state
 }
 

--- a/builder/common/step_key_pair_test.go
+++ b/builder/common/step_key_pair_test.go
@@ -52,7 +52,7 @@ func keyPairState() multistep.StateBag {
 }
 
 //Add "AndType" to the name of this test
-func TestStepKeyPair_callsCreateKeyPairOnceWithName(t *testing.T) {
+func TestStepKeyPair_withDefault(t *testing.T) {
 	//testSSHTemporaryKeyPair := communicator.SSHTemporaryKeyPair{SSHTemporaryKeyPairType: "rsa"}
 	testSSH := communicator.SSH{
 		SSHTemporaryKeyPairName: "temp-key-name",

--- a/builder/common/step_key_pair_test.go
+++ b/builder/common/step_key_pair_test.go
@@ -51,7 +51,6 @@ func keyPairState() multistep.StateBag {
 	return state
 }
 
-//Add "AndType" to the name of this test
 func TestStepKeyPair_withDefault(t *testing.T) {
 	//testSSHTemporaryKeyPair := communicator.SSHTemporaryKeyPair{SSHTemporaryKeyPairType: "rsa"}
 	testSSH := communicator.SSH{

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -185,6 +185,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
+    state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -185,7 +185,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
-    state.Put("region", ec2conn.Config.Region)
+	state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step

--- a/builder/ebs/test-fixtures/rsa_ssh_keypair.pkr.hcl
+++ b/builder/ebs/test-fixtures/rsa_ssh_keypair.pkr.hcl
@@ -13,7 +13,7 @@ source "amazon-ebs" "basic-example" {
   region           = "us-east-1"
   source_ami       = data.amazon-ami.test.id
   instance_type    = "t2.micro"
-  ami_name         = "packer_ed25519_ssh_keypair_acctest"
+  ami_name         = "packer_rsa_ssh_keypair_acctest"
   communicator     = "ssh"
   ssh_username     = "ubuntu"
   skip_create_ami  = true

--- a/builder/ebs/test-fixtures/rsa_ssh_keypair.pkr.hcl
+++ b/builder/ebs/test-fixtures/rsa_ssh_keypair.pkr.hcl
@@ -1,0 +1,30 @@
+data "amazon-ami" "test" {
+  filters = {
+    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["099720109477"]
+  region      = "us-east-1"
+}
+
+source "amazon-ebs" "basic-example" {
+  region           = "us-east-1"
+  source_ami       = data.amazon-ami.test.id
+  instance_type    = "t2.micro"
+  ami_name         = "packer_ed25519_ssh_keypair_acctest"
+  communicator     = "ssh"
+  ssh_username     = "ubuntu"
+  skip_create_ami  = true
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.basic-example"
+  ]
+
+  provisioner "shell" {
+    inline = ["echo 'Hello from the other side'", "cat ~/.ssh/authorized_keys"]
+  }
+}

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -213,7 +213,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
-    state.Put("region", ec2conn.Config.Region)
+	state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -213,6 +213,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
+    state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -178,6 +178,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("iam", iam)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
+    state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -178,7 +178,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("iam", iam)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
-    state.Put("region", ec2conn.Config.Region)
+	state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -253,6 +253,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
+    state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -253,7 +253,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	state.Put("awsSession", session)
 	state.Put("hook", hook)
 	state.Put("ui", ui)
-    state.Put("region", ec2conn.Config.Region)
+	state.Put("region", ec2conn.Config.Region)
 	generatedData := &packerbuilderdata.GeneratedData{State: state}
 
 	var instanceStep multistep.Step


### PR DESCRIPTION
After reviewing https://github.com/hashicorp/packer-plugin-amazon/pull/179 with Wilken we came to the conclusion that we should add a unit test to the KeyPair step so that the aforementioned PR can be tested (just need to remove comments in step_key_pair_test)

I ended up having to make a small change to each builder to put the region in the state before the steps are run, previously step_key_pair would access Region through the ec2 object (ec2conn.Config.Region), since we now cast that as an ec2iface to be able to mock it in the test, we are no longer able to access the Config object within the step, since the interface does not know about the Config object (might be an upstream fix there)