### PR TITLE
Change error handling with CSV Parsing of filters

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -140,7 +140,7 @@ type Config struct {
 	//This will fail unless *exactly* one AMI is returned. In the above example,
 	//`most_recent` will cause this to succeed by selecting the newest image.
 	//
-	//-   `filters` (map{key string, value string | comma separated string}) -
+	//-   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) -
 	//  filters used to select a `source_ami`.
 	//	NOTE: This will fail unless *exactly* one AMI is returned. Any filter
 	//	described in the docs for

--- a/builder/common/ami_filter.go
+++ b/builder/common/ami_filter.go
@@ -44,7 +44,12 @@ func (d *AmiFilterOptions) NoOwner() bool {
 func (d *AmiFilterOptions) GetFilteredImage(params *ec2.DescribeImagesInput, ec2conn *ec2.EC2) (*ec2.Image, error) {
 	// We have filters to apply
 	if len(d.Filters) > 0 {
-		params.Filters = buildEc2Filters(d.Filters)
+		amiFilters, err := buildEc2Filters(d.Filters)
+		if err != nil {
+			err := fmt.Errorf("Couldn't parse ami filters: %s", err)
+			return nil, err
+		}
+		params.Filters = amiFilters
 	}
 	if len(d.Owners) > 0 {
 		params.Owners = d.GetOwners()

--- a/builder/common/build_filter.go
+++ b/builder/common/build_filter.go
@@ -2,14 +2,13 @@ package common
 
 import (
 	"encoding/csv"
-	"log"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
 // Build a slice of EC2 (AMI/Subnet/VPC) filter options from the filters provided.
-func buildEc2Filters(input map[string]string) []*ec2.Filter {
+func buildEc2Filters(input map[string]string) ([]*ec2.Filter, error) {
 	var filters []*ec2.Filter
 
 	for k, v := range input {
@@ -21,9 +20,8 @@ func buildEc2Filters(input map[string]string) []*ec2.Filter {
 
 		values, err := csvReader.Read()
 		if err != nil {
-			log.Fatal(err)
+			return nil, err
 		}
-
 		for _, r := range values {
 			var value = r
 			b = append(b, &value)
@@ -34,5 +32,5 @@ func buildEc2Filters(input map[string]string) []*ec2.Filter {
 			Values: b,
 		})
 	}
-	return filters
+	return filters, nil
 }

--- a/builder/common/build_filter_test.go
+++ b/builder/common/build_filter_test.go
@@ -19,8 +19,11 @@ func TestStepSourceAmiInfo_BuildFilter_SingleValue(t *testing.T) {
 		filter_key3: filter_value3,
 	}
 
-	outputFilter := buildEc2Filters(inputFilter)
+	outputFilter, err := buildEc2Filters(inputFilter)
 
+	if err != nil {
+		t.Fatalf("Fail: should not have failed to parse filter:")
+	}
 	testFilter := map[string]string{
 		filter_key:  filter_value,
 		filter_key2: strings.TrimSpace(filter_value2),
@@ -58,8 +61,11 @@ func TestStepSourceAmiInfo_BuildFilter_ListValue(t *testing.T) {
 		filter_key3: filter_value3,
 	}
 
-	outputFilter := buildEc2Filters(inputFilter)
+	outputFilter, err := buildEc2Filters(inputFilter)
 
+	if err != nil {
+		t.Fatalf("Fail: should not have failed to parse filter:")
+	}
 	testFilter := map[string][]string{
 		filter_key:  {"foo1", "foo1-2", "foo1-3"},
 		filter_key2: {"foo2-1", "foo2-2", "foo2-3"},

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -225,7 +225,7 @@ type RunConfig struct {
 	//
 	// This selects the SG's with tag `Class` with the value `packer`.
 	//
-	// -   `filters` (map of strings) - filters used to select a
+	// -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a
 	//     `security_group_ids`. Any filter described in the docs for
 	//     [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html)
 	//     is valid.
@@ -297,7 +297,7 @@ type RunConfig struct {
 	//   This will fail unless *exactly* one AMI is returned. In the above example,
 	//   `most_recent` will cause this to succeed by selecting the newest image.
 	//
-	//   -   `filters` (map of strings) - filters used to select a `source_ami`.
+	//   -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a `source_ami`.
 	//       NOTE: This will fail unless *exactly* one AMI is returned. Any filter
 	//       described in the docs for
 	//       [DescribeImages](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html)
@@ -395,7 +395,7 @@ type RunConfig struct {
 	//   Subnet is returned. By using `most_free` or `random` one will be selected
 	//   from those matching the filter.
 	//
-	//   -   `filters` (map of strings) - filters used to select a `subnet_id`.
+	//   -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a `subnet_id`.
 	//       NOTE: This will fail unless *exactly* one Subnet is returned. Any
 	//       filter described in the docs for
 	//       [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html)
@@ -535,7 +535,7 @@ type RunConfig struct {
 	// the default VPC, and have a IPv4 CIDR block of `/24`. NOTE: This will fail
 	// unless *exactly* one VPC is returned.
 	//
-	// -   `filters` (map of strings) - filters used to select a `vpc_id`. NOTE:
+	// -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a `vpc_id`. NOTE:
 	//     This will fail unless *exactly* one VPC is returned. Any filter
 	//     described in the docs for
 	//     [DescribeVpcs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcs.html)

--- a/builder/common/step_security_group.go
+++ b/builder/common/step_security_group.go
@@ -58,7 +58,14 @@ func (s *StepSecurityGroup) Run(ctx context.Context, state multistep.StateBag) m
 		if vpcId != "" {
 			s.SecurityGroupFilter.Filters["vpc-id"] = vpcId
 		}
-		params.Filters = buildEc2Filters(s.SecurityGroupFilter.Filters)
+		securityGroupFilters, err := buildEc2Filters(s.SecurityGroupFilter.Filters)
+		if err != nil {
+			err := fmt.Errorf("Couldn't parse security groups filters: %s", err)
+			log.Printf("[DEBUG] %s", err.Error())
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+		params.Filters = securityGroupFilters
 
 		log.Printf("Using SecurityGroup Filters %v", params)
 

--- a/docs-partials/builder/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/chroot/Config-not-required.mdx
@@ -100,7 +100,7 @@
   This will fail unless *exactly* one AMI is returned. In the above example,
   `most_recent` will cause this to succeed by selecting the newest image.
   
-  -   `filters` (map{key string, value string | comma separated string}) -
+  -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) -
    filters used to select a `source_ami`.
   	NOTE: This will fail unless *exactly* one AMI is returned. Any filter
   	described in the docs for

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -139,7 +139,7 @@
   
   This selects the SG's with tag `Class` with the value `packer`.
   
-  -   `filters` (map of strings) - filters used to select a
+  -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a
       `security_group_ids`. Any filter described in the docs for
       [DescribeSecurityGroups](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html)
       is valid.
@@ -207,7 +207,7 @@
     This will fail unless *exactly* one AMI is returned. In the above example,
     `most_recent` will cause this to succeed by selecting the newest image.
   
-    -   `filters` (map of strings) - filters used to select a `source_ami`.
+    -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a `source_ami`.
         NOTE: This will fail unless *exactly* one AMI is returned. Any filter
         described in the docs for
         [DescribeImages](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeImages.html)
@@ -299,7 +299,7 @@
     Subnet is returned. By using `most_free` or `random` one will be selected
     from those matching the filter.
   
-    -   `filters` (map of strings) - filters used to select a `subnet_id`.
+    -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a `subnet_id`.
         NOTE: This will fail unless *exactly* one Subnet is returned. Any
         filter described in the docs for
         [DescribeSubnets](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html)
@@ -437,7 +437,7 @@
   the default VPC, and have a IPv4 CIDR block of `/24`. NOTE: This will fail
   unless *exactly* one VPC is returned.
   
-  -   `filters` (map of strings) - filters used to select a `vpc_id`. NOTE:
+  -   `filters` (map[string,string] | multiple filters are allowed when seperated by commas) - filters used to select a `vpc_id`. NOTE:
       This will fail unless *exactly* one VPC is returned. Any filter
       described in the docs for
       [DescribeVpcs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcs.html)


### PR DESCRIPTION
After https://github.com/hashicorp/packer-plugin-amazon/pull/174 @azr pointed out that we should bubble up errors from csv parsing, this PR bubbles up that error, and addresses some other docs feedback.

For testing I added checks that errors aren't thrown to both existing filtering unit tests, I felt like adding additional tests wasn't worth it for this error, we can decide to refactor the build filter class to accept a mocked csv parser if folks want to though.

Addresses feedback from: https://github.com/hashicorp/packer-plugin-amazon/pull/174#discussion_r790534015 and https://github.com/hashicorp/packer-plugin-amazon/pull/174#discussion_r790903152


