### PR TITLE
wilken/keypair type fix

### DIFF
--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -607,14 +607,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 		c.Comm.SSHTemporaryKeyPairName = fmt.Sprintf("packer_%s", uuid.TimeOrderedUUID())
 
-		if c.Comm.SSHTemporaryKeyPairType == "" {
-			c.Comm.SSHTemporaryKeyPairType = "rsa"
-		}
+	}
 
-		if c.Comm.SSHTemporaryKeyPairType != "rsa" && c.Comm.SSHTemporaryKeyPairType != "ed25519" {
-			msg := fmt.Errorf("temporary_key_pair_type requires either rsa or ed25519 as its value")
-			errs = append(errs, msg)
-		}
+	if c.Comm.SSHTemporaryKeyPairType == "" {
+		c.Comm.SSHTemporaryKeyPairType = "rsa"
 	}
 
 	if c.WindowsPasswordTimeout == 0 {
@@ -635,6 +631,11 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 
 	if c.Metadata.HttpPutResponseHopLimit == 0 {
 		c.Metadata.HttpPutResponseHopLimit = 1
+	}
+
+	if c.Comm.SSHTemporaryKeyPairType != "rsa" && c.Comm.SSHTemporaryKeyPairType != "ed25519" {
+		msg := fmt.Errorf("temporary_key_pair_type requires either rsa or ed25519 as its value")
+		errs = append(errs, msg)
 	}
 
 	if c.Metadata.HttpEndpoint != "enabled" && c.Metadata.HttpEndpoint != "disabled" {

--- a/builder/common/run_config_test.go
+++ b/builder/common/run_config_test.go
@@ -232,13 +232,27 @@ func TestRunConfigPrepare_TemporaryKeyPairName(t *testing.T) {
 
 func TestRunConfigPrepare_TemporaryKeyPairTypeDefault(t *testing.T) {
 	c := testConfig()
-	c.Comm.SSHTemporaryKeyPairType = ""
-	if err := c.Prepare(nil); len(err) != 0 {
-		t.Fatalf("err: %s", err)
+	tc := []struct {
+		desc                     string
+		keyPairName, keyPairType string
+		expectedKeyType          string
+	}{
+		{desc: "no temporary_key_pair_* config settings should use defaults", expectedKeyType: "rsa"},
+		{desc: "setting a temporary_key_pair_name should set default key pair type", keyPairName: "local.name", expectedKeyType: "rsa"},
 	}
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			c.Comm.SSHTemporaryKeyPairName = tt.keyPairName
+			c.Comm.SSHTemporaryKeyPairType = tt.keyPairType
+			if err := c.Prepare(nil); len(err) != 0 {
+				t.Fatalf("err: %s", err)
+			}
 
-	if c.Comm.SSHTemporaryKeyPairType != "rsa" {
-		t.Fatal("keypair type should have defaulted to rsa")
+			if c.Comm.SSHTemporaryKeyPairType != tt.expectedKeyType {
+				t.Fatal("keypair type should have defaulted to rsa")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
- Add failing test case for #184
- Fix defaults for SSHTemporaryKeyPairType when SSHTemporaryKeyPairName is set


Closes #184 