### PR TITLE
Remove default tagging

### DIFF
--- a/builder/common/ami_config.go
+++ b/builder/common/ami_config.go
@@ -57,6 +57,8 @@ type AMIConfig struct {
 	// Key/value pair tags applied to the AMI. This is a [template
 	// engine](/docs/templates/legacy_json_templates/engine), see [Build template
 	// data](#build-template-data) for more information.
+	//
+	// The builder no longer adds a "Name": "Packer Builder" entry to the tags.
 	AMITags map[string]string `mapstructure:"tags" required:"false"`
 	// Same as [`tags`](#tags) but defined as a singular repeatable block
 	// containing a `key` and a `value` field. In HCL2 mode the

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -91,11 +91,6 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 
 	var instanceId string
 
-	ui.Say("Adding tags to source instance")
-	if _, exists := s.Tags["Name"]; !exists {
-		s.Tags["Name"] = "Packer Builder"
-	}
-
 	ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, *ec2conn.Config.Region, state)
 	if err != nil {
 		err := fmt.Errorf("Error tagging source instance: %s", err)

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -213,13 +213,6 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	var instanceId string
 
 	ui.Say("Interpolating tags for spot instance...")
-	// s.Tags will tag the eventually launched instance
-	// s.SpotTags apply to the spot request itself, and do not automatically
-	// get applied to the spot instance that is launched once the request is
-	// fulfilled
-	if _, exists := s.Tags["Name"]; !exists {
-		s.Tags["Name"] = "Packer Builder"
-	}
 
 	// Convert tags from the tag map provided by the user into *ec2.Tag s
 	ec2Tags, err := TagMap(s.Tags).EC2Tags(s.Ctx, s.Region, state)

--- a/docs-partials/builder/common/AMIConfig-not-required.mdx
+++ b/docs-partials/builder/common/AMIConfig-not-required.mdx
@@ -39,6 +39,8 @@
 - `tags` (map[string]string) - Key/value pair tags applied to the AMI. This is a [template
   engine](/docs/templates/legacy_json_templates/engine), see [Build template
   data](#build-template-data) for more information.
+  
+  The builder no longer adds a "Name": "Packer Builder" entry to the tags.
 
 - `tag` ([]{key string, value string}) - Same as [`tags`](#tags) but defined as a singular repeatable block
   containing a `key` and a `value` field. In HCL2 mode the


### PR DESCRIPTION
This fixes #155 and a is breaking change.
We should probably bump the minor version for the next release.