### PR TITLE
docs: specify valid values for ami_groups

### DIFF
--- a/builder/common/ami_config.go
+++ b/builder/common/ami_config.go
@@ -33,7 +33,8 @@ type AMIConfig struct {
 	AMIUsers []string `mapstructure:"ami_users" required:"false"`
 	// A list of groups that have access to
 	// launch the resulting AMI(s). By default no groups have permission to launch
-	// the AMI. all will make the AMI publicly accessible.
+	// the AMI. `all` will make the AMI publicly accessible.
+	// AWS currently doesn't accept any value other than "all"
 	AMIGroups []string `mapstructure:"ami_groups" required:"false"`
 	// A list of Amazon Resource Names (ARN) of AWS Organizations that have access to
 	// launch the resulting AMI(s). By default no organizations have permission to launch

--- a/docs-partials/builder/common/AMIConfig-not-required.mdx
+++ b/docs-partials/builder/common/AMIConfig-not-required.mdx
@@ -15,7 +15,8 @@
 
 - `ami_groups` ([]string) - A list of groups that have access to
   launch the resulting AMI(s). By default no groups have permission to launch
-  the AMI. all will make the AMI publicly accessible. AWS currently doesn't accept any value other than "all".
+  the AMI. `all` will make the AMI publicly accessible.
+  AWS currently doesn't accept any value other than "all"
 
 - `ami_org_arns` ([]string) - A list of Amazon Resource Names (ARN) of AWS Organizations that have access to
   launch the resulting AMI(s). By default no organizations have permission to launch
@@ -39,7 +40,7 @@
 - `tags` (map[string]string) - Key/value pair tags applied to the AMI. This is a [template
   engine](/docs/templates/legacy_json_templates/engine), see [Build template
   data](#build-template-data) for more information.
-  
+
   The builder no longer adds a "Name": "Packer Builder" entry to the tags.
 
 - `tag` ([]{key string, value string}) - Same as [`tags`](#tags) but defined as a singular repeatable block
@@ -50,7 +51,7 @@
 - `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport) on
   HVM-compatible AMIs. If set, add `ec2:ModifyInstanceAttribute` to your
   AWS IAM policy.
-  
+
   Note: you must make sure enhanced networking is enabled on your
   instance. See [Amazon's documentation on enabling enhanced
   networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
@@ -74,12 +75,12 @@
   the encryption setting to what it was in the source image. Setting false
   will result in an unencrypted image, and true will result in an encrypted
   one.
-  
+
   If you have used the `launch_block_device_mappings` to set an encryption
   key and that key is the same as the one you want the image encrypted with
   at the end, then you don't need to set this field; leaving it empty will
   prevent an unnecessary extra copy step and save you some time.
-  
+
   Please note that if you are using an account with the global "Always
   encrypt new EBS volumes" option set to `true`, Packer will be unable to
   override this setting, and the final image will be encrypted whether
@@ -89,17 +90,17 @@
   only applies to the main `region` -- any regions the AMI gets copied to
   copied will be encrypted by the default EBS KMS key for that region,
   unless you set region-specific keys in AMIRegionKMSKeyIDs.
-  
+
   Set this value if you select `encrypt_boot`, but don't want to use the
   region's default KMS key.
-  
+
   If you have a custom kms key you'd like to apply to the launch volume,
   and are only building in one region, it is more efficient to leave this
   and `encrypt_boot` empty and to instead set the key id in the
   launch_block_device_mappings (you can find an example below). This saves
   potentially many minutes at the end of the build by preventing Packer
   from having to copy and re-encrypt the image at the end of the build.
-  
+
   For valid formats see *KmsKeyId* in the [AWS API docs -
   CopyImage](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html).
   This field is validated by Packer, when using an alias, you will have to
@@ -115,7 +116,7 @@
   conjunction with `snapshot_users` -- in that situation you must use
   custom keys. For valid formats see *KmsKeyId* in the [AWS API docs -
   CopyImage](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html).
-  
+
   This option supercedes the `kms_key_id` option -- if you set both, and
   they are different, Packer will respect the value in
   `region_kms_key_ids` for your build region and silently disregard the

--- a/docs-partials/builder/common/AMIConfig-not-required.mdx
+++ b/docs-partials/builder/common/AMIConfig-not-required.mdx
@@ -15,7 +15,7 @@
 
 - `ami_groups` ([]string) - A list of groups that have access to
   launch the resulting AMI(s). By default no groups have permission to launch
-  the AMI. all will make the AMI publicly accessible.
+  the AMI. all will make the AMI publicly accessible. AWS currently doesn't accept any value other than "all".
 
 - `ami_org_arns` ([]string) - A list of Amazon Resource Names (ARN) of AWS Organizations that have access to
   launch the resulting AMI(s). By default no organizations have permission to launch

--- a/docs-partials/builder/common/AMIConfig-not-required.mdx
+++ b/docs-partials/builder/common/AMIConfig-not-required.mdx
@@ -40,7 +40,7 @@
 - `tags` (map[string]string) - Key/value pair tags applied to the AMI. This is a [template
   engine](/docs/templates/legacy_json_templates/engine), see [Build template
   data](#build-template-data) for more information.
-
+  
   The builder no longer adds a "Name": "Packer Builder" entry to the tags.
 
 - `tag` ([]{key string, value string}) - Same as [`tags`](#tags) but defined as a singular repeatable block
@@ -51,7 +51,7 @@
 - `ena_support` (boolean) - Enable enhanced networking (ENA but not SriovNetSupport) on
   HVM-compatible AMIs. If set, add `ec2:ModifyInstanceAttribute` to your
   AWS IAM policy.
-
+  
   Note: you must make sure enhanced networking is enabled on your
   instance. See [Amazon's documentation on enabling enhanced
   networking](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enhanced-networking.html#enabling_enhanced_networking).
@@ -75,12 +75,12 @@
   the encryption setting to what it was in the source image. Setting false
   will result in an unencrypted image, and true will result in an encrypted
   one.
-
+  
   If you have used the `launch_block_device_mappings` to set an encryption
   key and that key is the same as the one you want the image encrypted with
   at the end, then you don't need to set this field; leaving it empty will
   prevent an unnecessary extra copy step and save you some time.
-
+  
   Please note that if you are using an account with the global "Always
   encrypt new EBS volumes" option set to `true`, Packer will be unable to
   override this setting, and the final image will be encrypted whether
@@ -90,17 +90,17 @@
   only applies to the main `region` -- any regions the AMI gets copied to
   copied will be encrypted by the default EBS KMS key for that region,
   unless you set region-specific keys in AMIRegionKMSKeyIDs.
-
+  
   Set this value if you select `encrypt_boot`, but don't want to use the
   region's default KMS key.
-
+  
   If you have a custom kms key you'd like to apply to the launch volume,
   and are only building in one region, it is more efficient to leave this
   and `encrypt_boot` empty and to instead set the key id in the
   launch_block_device_mappings (you can find an example below). This saves
   potentially many minutes at the end of the build by preventing Packer
   from having to copy and re-encrypt the image at the end of the build.
-
+  
   For valid formats see *KmsKeyId* in the [AWS API docs -
   CopyImage](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html).
   This field is validated by Packer, when using an alias, you will have to
@@ -116,7 +116,7 @@
   conjunction with `snapshot_users` -- in that situation you must use
   custom keys. For valid formats see *KmsKeyId* in the [AWS API docs -
   CopyImage](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CopyImage.html).
-
+  
   This option supercedes the `kms_key_id` option -- if you set both, and
   they are different, Packer will respect the value in
   `region_kms_key_ids` for your build region and silently disregard the


### PR DESCRIPTION
in https://github.com/hashicorp/packer/commit/b20e26be17b56e893d9b29945441041824d0e110 a limit for the ami_groups was added but that is not in this documentation anymore, even though the official docs suggest this is still the only value possible: https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_LaunchPermission.html
