### PR TITLE
Handle empty source tags in restricted regions

### DIFF
--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -339,11 +339,14 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		},
 			RetryDelay: (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 		}.Run(ctx, func(ctx context.Context) error {
-			_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
-				Tags:      ec2Tags,
-				Resources: []*string{instance.InstanceId},
-			})
-			return err
+			if len(ec2Tags) > 0 {
+				_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
+					Tags:      ec2Tags,
+					Resources: []*string{instance.InstanceId},
+				})
+				return err
+			}
+			return nil
 		})
 
 		if err != nil {


### PR DESCRIPTION
Fix build failure when no source instance tags are present in restricted
regions.

e83d836e removed default tagging for source instances which introduces
the potential for launching an instance with an empty ec2Tags list.

This was handled for regions that support tagging on instance creation
but not in restricted regions (GovCloud and China) where tags are
applied to the instance after creation.
