### PR TITLE
Remove GovCloud from isRestricted run source param

### DIFF
--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -246,7 +246,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			InstanceMetadataTags:              b.config.Metadata.InstanceMetadataTags,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 			InstanceType:                      b.config.InstanceType,
-			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
+			IsRestricted:                      b.config.IsChinaCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
 			LicenseSpecifications:             b.config.LicenseSpecifications,

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -273,7 +273,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			InstanceMetadataTags:              b.config.Metadata.InstanceMetadataTags,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 			InstanceType:                      b.config.InstanceType,
-			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
+			IsRestricted:                      b.config.IsChinaCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
 			LicenseSpecifications:             b.config.LicenseSpecifications,

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -238,7 +238,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			InstanceMetadataTags:              b.config.Metadata.InstanceMetadataTags,
 			InstanceInitiatedShutdownBehavior: b.config.InstanceInitiatedShutdownBehavior,
 			InstanceType:                      b.config.InstanceType,
-			IsRestricted:                      b.config.IsChinaCloud() || b.config.IsGovCloud(),
+			IsRestricted:                      b.config.IsChinaCloud(),
 			SourceAMI:                         b.config.SourceAmi,
 			Tags:                              b.config.RunTags,
 			LicenseSpecifications:             b.config.LicenseSpecifications,

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -300,7 +300,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			EbsOptimized:             b.config.EbsOptimized,
 			EnableT2Unlimited:        b.config.EnableT2Unlimited,
 			InstanceType:             b.config.InstanceType,
-			IsRestricted:             b.config.IsChinaCloud() || b.config.IsGovCloud(),
+			IsRestricted:             b.config.IsChinaCloud(),
 			SourceAMI:                b.config.SourceAmi,
 			Tags:                     b.config.RunTags,
 			LicenseSpecifications:    b.config.LicenseSpecifications,


### PR DESCRIPTION
Tag-On Create for EC2 and EBS is now supported on GovCloud:
https://aws.amazon.com/about-aws/whats-new/2018/07/tag-on-create-for-amazon-ec2-and-amazon-ebs-is-now-available-in-the-aws-govcloud-region/

isRestrcted is only used to gate Tag-On Create and is no longer needed
for GovCloud.