### PR TITLE
Add throughput paramter to ami_root_device (#201)

### DIFF
--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -370,6 +370,7 @@ type FlatRootBlockDevice struct {
 	DeviceName          *string `mapstructure:"device_name" required:"false" cty:"device_name" hcl:"device_name"`
 	DeleteOnTermination *bool   `mapstructure:"delete_on_termination" required:"false" cty:"delete_on_termination" hcl:"delete_on_termination"`
 	IOPS                *int64  `mapstructure:"iops" required:"false" cty:"iops" hcl:"iops"`
+	Throughput          *int64  `mapstructure:"throughput" required:"false" cty:"throughput" hcl:"throughput"`
 	VolumeType          *string `mapstructure:"volume_type" required:"false" cty:"volume_type" hcl:"volume_type"`
 	VolumeSize          *int64  `mapstructure:"volume_size" required:"false" cty:"volume_size" hcl:"volume_size"`
 }
@@ -390,6 +391,7 @@ func (*FlatRootBlockDevice) HCL2Spec() map[string]hcldec.Spec {
 		"device_name":           &hcldec.AttrSpec{Name: "device_name", Type: cty.String, Required: false},
 		"delete_on_termination": &hcldec.AttrSpec{Name: "delete_on_termination", Type: cty.Bool, Required: false},
 		"iops":                  &hcldec.AttrSpec{Name: "iops", Type: cty.Number, Required: false},
+		"throughput":            &hcldec.AttrSpec{Name: "throughput", Type: cty.Number, Required: false},
 		"volume_type":           &hcldec.AttrSpec{Name: "volume_type", Type: cty.String, Required: false},
 		"volume_size":           &hcldec.AttrSpec{Name: "volume_size", Type: cty.Number, Required: false},
 	}

--- a/builder/ebssurrogate/root_block_device.go
+++ b/builder/ebssurrogate/root_block_device.go
@@ -25,6 +25,11 @@ type RootBlockDevice struct {
 	// IOPs
 	// for more information
 	IOPS int64 `mapstructure:"iops" required:"false"`
+	// The throughput for gp3 volumes, only valid for gp3 types
+	// See the documentation on
+	// [Throughput](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
+	// for more information
+	Throughput int64 `mapstructure:"throughput" required:"false"`
 	// The volume type. gp2 for General Purpose
 	// (SSD) volumes, io1 for Provisioned IOPS (SSD) volumes, st1 for
 	// Throughput Optimized HDD, sc1 for Cold HDD, and standard for
@@ -52,6 +57,14 @@ func (c *RootBlockDevice) Prepare(ctx *interpolate.Context) []error {
 
 	if c.IOPS < 0 {
 		errs = append(errs, errors.New("iops must be greater than 0"))
+	}
+
+	if c.VolumeType == "gp2" && c.Throughput != 0 {
+		errs = append(errs, errors.New("throughput may not be specified for a gp2 volume"))
+	}
+
+	if c.Throughput < 0 {
+		errs = append(errs, errors.New("throughput must be greater than 0"))
 	}
 
 	if c.VolumeSize < 0 {

--- a/builder/ebssurrogate/step_register_ami.go
+++ b/builder/ebssurrogate/step_register_ami.go
@@ -168,6 +168,9 @@ func (s *StepRegisterAMI) combineDevices(snapshotIds map[string]string) []*ec2.B
 		if *device.DeviceName == s.RootDevice.SourceDeviceName {
 			device.DeviceName = aws.String(s.RootDevice.DeviceName)
 		}
+		if s.RootDevice.Throughput != 0 && s.RootDevice.VolumeType == "gp3" {
+			*device.Ebs.Throughput = s.RootDevice.Throughput
+		}
 		devices[*device.DeviceName] = device
 	}
 

--- a/docs-partials/builder/ebssurrogate/RootBlockDevice-not-required.mdx
+++ b/docs-partials/builder/ebssurrogate/RootBlockDevice-not-required.mdx
@@ -17,6 +17,11 @@
   IOPs
   for more information
 
+- `throughput` (int64) - The throughput for gp3 volumes, only valid for gp3 types
+  See the documentation on
+  [Throughput](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html)
+  for more information
+
 - `volume_type` (string) - The volume type. gp2 for General Purpose
   (SSD) volumes, io1 for Provisioned IOPS (SSD) volumes, st1 for
   Throughput Optimized HDD, sc1 for Cold HDD, and standard for


### PR DESCRIPTION
Allow the throughput device parameter for gp3 volumes in
ami_root_device needed for the ebssurrogate builder.

This does not address AMIs being created without throughput set on the block device mapping if the source volume does not have the parameter set.

Closes #201 

