### PR TITLE
Update ami.mdx

### DIFF
--- a/docs/datasources/ami.mdx
+++ b/docs/datasources/ami.mdx
@@ -25,7 +25,7 @@ data "amazon-ami" "basic-example" {
         name = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
         root-device-type = "ebs"
     }
-    owners = ["099720109477"]
+    owners = ["099720109477", "513442679011"] #Canonical 
     most_recent = true
 }
 ```


### PR DESCRIPTION
Include Canonical's GovCloud OwnerID in the list of possible valid owners.



