### PR TITLE
Mention source config settings for AWS polling

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -410,6 +410,15 @@ generally during image copy/encryption. Possible reasons for the error include:
   - `AWS_POLL_DELAY_SECONDS` - How many seconds to wait in between status update
     requests. Generally defaults to 2 or 5 seconds, depending on the task.
 
+  Alternatively, you can configure these settings in source section of the packer
+  configuration file, for example:
+  ```
+  aws_polling {
+    delay_seconds = 40
+    max_attempts  = 5
+  }
+  ```
+
 - You are using short-lived credentials that expired during the build. If this
   is the problem, you may also see `RequestExpired: Request has expired.`
   errors displayed in the Packer output:


### PR DESCRIPTION
The default polling configuration is too short for AWS MacOS images due to AWS taking a very long time to shut down an instance and create an image. Instead of *always* setting the environment variables, it's much better to use the config file settings in that case (I don't know how often I forgot these env variables until I discovered that they could be set in the config file).