### PR TITLE
Enable csv LazyQuotes in build_filter

### DIFF
--- a/builder/common/build_filter.go
+++ b/builder/common/build_filter.go
@@ -17,6 +17,7 @@ func buildEc2Filters(input map[string]string) ([]*ec2.Filter, error) {
 		a := k
 		csvReader := csv.NewReader(strings.NewReader(v))
 		csvReader.TrimLeadingSpace = true
+		csvReader.LazyQuotes = true
 
 		values, err := csvReader.Read()
 		if err != nil {

--- a/builder/common/build_filter_test.go
+++ b/builder/common/build_filter_test.go
@@ -94,3 +94,41 @@ func TestStepSourceAmiInfo_BuildFilter_ListValue(t *testing.T) {
 		}
 	}
 }
+
+func TestStepSourceAmiInfo_BuildFilter_ValueWithQuote(t *testing.T) {
+	filter_key := "tag:test"
+	filter_value := "{\"purpose\":\"testing\"}"
+	filter_key2 := "tag:test"
+	filter_value2 := " {\"purpose\":\"testing\"}"
+
+	inputFilter := map[string]string{
+		filter_key:  filter_value,
+		filter_key2: filter_value2,
+	}
+
+	outputFilter, err := buildEc2Filters(inputFilter)
+
+	if err != nil {
+		t.Fatalf("Fail: should not have failed to parse filter: %v", err)
+	}
+	testFilter := map[string]string{
+		filter_key:  filter_value,
+		filter_key2: strings.TrimSpace(filter_value2),
+	}
+
+	// deconstruct filter back into things we can test
+	foundMap := map[string]bool{filter_key: false, filter_key2: false}
+	for _, filter := range outputFilter {
+		for key, value := range testFilter {
+			if *filter.Name == key && *filter.Values[0] == value {
+				foundMap[key] = true
+			}
+		}
+	}
+
+	for k, v := range foundMap {
+		if !v {
+			t.Fatalf("Fail: should have found value for key: %s", k)
+		}
+	}
+}


### PR DESCRIPTION
Currently, if a filter has quotes in the value, it fails with:

```
Build 'amazon-ebs.ebs' errored after 1 second 208 milliseconds: Couldn't parse subnet filters: parse error on line 1, column 2: bare " in non-quoted-field
```

I believe this is because https://github.com/hashicorp/packer-plugin-amazon/pull/174. This adds a test to confirm and then enables `LazyQuotes` which I got the idea from https://stackoverflow.com/questions/31326659/golang-csv-error-bare-in-non-quoted-field. The test now passes.  

Closes https://github.com/hashicorp/packer-plugin-amazon/issues/226