### PR TITLE
ebs/ami_deprecation: don't crash when AMIs are nil

### DIFF
--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -371,7 +371,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Ctx:                b.config.ctx,
 		},
 		&stepEnableDeprecation{
-			DeprecationTime: b.config.DeprecationTime,
+			DeprecationTime:    b.config.DeprecationTime,
+			AMISkipCreateImage: b.config.AMISkipCreateImage,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:       &b.config.AccessConfig,

--- a/builder/ebs/step_enable_deprecation.go
+++ b/builder/ebs/step_enable_deprecation.go
@@ -22,7 +22,13 @@ func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBa
 	}
 
 	ec2conn := state.Get("ec2").(*ec2.EC2)
-	amis := state.Get("amis").(map[string]string)
+	amis, ok := state.Get("amis").(map[string]string)
+	if !ok {
+		err := fmt.Errorf("no AMIs found in state to deprecate")
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
 
 	deprecationTime, _ := time.Parse(time.RFC3339, s.DeprecationTime)
 	for _, ami := range amis {

--- a/builder/ebs/step_enable_deprecation.go
+++ b/builder/ebs/step_enable_deprecation.go
@@ -11,12 +11,13 @@ import (
 )
 
 type stepEnableDeprecation struct {
-	DeprecationTime string
+	DeprecationTime    string
+	AMISkipCreateImage bool
 }
 
 func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
-	if s.DeprecationTime == "" {
+	if s.AMISkipCreateImage || s.DeprecationTime == "" {
 		ui.Say("Skipping Enable AMI deprecation...")
 		return multistep.ActionContinue
 	}


### PR DESCRIPTION
When a build file specifies a deprecation time on an AMI, and includes
the skip_create_ami directive in the configuration, the AMI map ends up
not being created in the state for the build, causing the depreciation
step to panic on an interface conversion.

This commit avoids such a problem by checking if the AMI map is indeed a
map and not nil before proceeding.
If it is not the expected type, we stop the build.

Closes #224 