### PR TITLE
Update spot instance run to handle empty tags set

### DIFF
--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -483,6 +483,10 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 	},
 		RetryDelay: (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 	}.Run(ctx, func(ctx context.Context) error {
+		if len(ec2Tags) == 0 {
+			return nil
+		}
+
 		_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
 			Tags:      ec2Tags,
 			Resources: []*string{instance.InstanceId},
@@ -490,7 +494,7 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		return err
 	})
 
-	if err != nil {
+	if len(ec2Tags) > 0 && err != nil {
 		err := fmt.Errorf("Error tagging source instance: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())


### PR DESCRIPTION
With the removal of the default Packer Builder tag in #191 the default
set of tags for a source instance is empty, which throws an error when trying to
create a tag input with an empty set. This error will not occur if the
run_tags attribute is provided. But since Packer was injecting a default
tag this issue never manifested itself.

Closes #223
