### PR TITLE
Change AssociatePublicIpAddress to a bool pointer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ main
 dist/*
 packer-plugin-amazon
 .docs
+.DS_Store

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
+	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/hashicorp/packer-plugin-sdk/uuid"
 )
@@ -88,8 +89,8 @@ type MetadataOptions struct {
 type RunConfig struct {
 	// If using a non-default VPC,
 	// public IP addresses are not provided by default. If this is true, your
-	// new instance will get a Public IP. default: false
-	AssociatePublicIpAddress bool `mapstructure:"associate_public_ip_address" required:"false"`
+	// new instance will get a Public IP. default: unset
+	AssociatePublicIpAddress confighelper.Trilean `mapstructure:"associate_public_ip_address" required:"false"`
 	// Destination availability zone to launch
 	// instance in. Leave this empty to allow Amazon to auto-assign.
 	AvailabilityZone string `mapstructure:"availability_zone" required:"false"`

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -16,12 +16,13 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/retry"
+	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
 type StepRunSourceInstance struct {
 	PollingConfig                     *AWSPollingConfig
-	AssociatePublicIpAddress          bool
+	AssociatePublicIpAddress          confighelper.Trilean
 	LaunchMappings                    EC2BlockDeviceMappingsBuilder
 	Comm                              *communicator.Config
 	Ctx                               interpolate.Context
@@ -191,11 +192,11 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 
 	subnetId := state.Get("subnet_id").(string)
 
-	if subnetId != "" && s.AssociatePublicIpAddress {
+	if subnetId != "" && s.AssociatePublicIpAddress != confighelper.TriUnset {
 		runOpts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{
 			{
 				DeviceIndex:              aws.Int64(0),
-				AssociatePublicIpAddress: &s.AssociatePublicIpAddress,
+				AssociatePublicIpAddress: s.AssociatePublicIpAddress.ToBoolPointer(),
 				SubnetId:                 aws.String(subnetId),
 				Groups:                   securityGroupIds,
 				DeleteOnTermination:      aws.Bool(true),

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -18,6 +18,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/random"
 	"github.com/hashicorp/packer-plugin-sdk/retry"
+	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
@@ -27,7 +28,7 @@ type EC2BlockDeviceMappingsBuilder interface {
 
 type StepRunSpotInstance struct {
 	PollingConfig                     *AWSPollingConfig
-	AssociatePublicIpAddress          bool
+	AssociatePublicIpAddress          confighelper.Trilean
 	LaunchMappings                    EC2BlockDeviceMappingsBuilder
 	BlockDurationMinutes              int64
 	Debug                             bool
@@ -138,8 +139,8 @@ func (s *StepRunSpotInstance) CreateTemplateData(userData *string, az string,
 			DeviceIndex:         aws.Int64(0),
 			SubnetId:            aws.String(subnetId),
 		}
-		if s.AssociatePublicIpAddress {
-			networkInterface.SetAssociatePublicIpAddress(s.AssociatePublicIpAddress)
+		if s.AssociatePublicIpAddress != confighelper.TriUnset {
+			networkInterface.SetAssociatePublicIpAddress(*s.AssociatePublicIpAddress.ToBoolPointer())
 		}
 		templateData.SetNetworkInterfaces([]*ec2.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{&networkInterface})
 	} else {

--- a/builder/common/step_run_spot_instance_test.go
+++ b/builder/common/step_run_spot_instance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 // Create statebag for running test
@@ -32,7 +33,7 @@ func tStateSpot() multistep.StateBag {
 func getBasicStep() *StepRunSpotInstance {
 	stepRunSpotInstance := StepRunSpotInstance{
 		PollingConfig:            new(AWSPollingConfig),
-		AssociatePublicIpAddress: false,
+		AssociatePublicIpAddress: confighelper.TriUnset,
 		LaunchMappings:           BlockDevices{},
 		BlockDurationMinutes:     0,
 		Debug:                    false,

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -1,8 +1,8 @@
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
-- `associate_public_ip_address` (bool) - If using a non-default VPC,
+- `associate_public_ip_address` (confighelper.Trilean) - If using a non-default VPC,
   public IP addresses are not provided by default. If this is true, your
-  new instance will get a Public IP. default: false
+  new instance will get a Public IP. default: unset
 
 - `availability_zone` (string) - Destination availability zone to launch
   instance in. Leave this empty to allow Amazon to auto-assign.


### PR DESCRIPTION
Change AssociatePublicIpAddress to a bool pointer, making it a tristate variable as it's already defined on HCL. 

This enables to explicitly set a `NetworkInterface` with `AssociatePublicIpAddress` set to false.

We tested the built plugin on our AWS account with the SCP rule mentioned on #240, it works perfectly. 

Closes #240 
