### PR TITLE
Remove tags from InstanceMetadataOptionsRequest when in the default state to fix launch issue for unsupported regions

### DIFF
--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -78,6 +78,7 @@ type MetadataOptions struct {
 	// Defaults to 1.
 	HttpPutResponseHopLimit int64 `mapstructure:"http_put_response_hop_limit" required:"false"`
 	// A string to enable or disable access to instance tags from the instance metadata. Defaults to disabled.
+	// Access to instance metadata tags is available for commercial regions. For non-commercial regions please check availability before enabling.
 	// Accepts either "enabled" or "disabled"
 	InstanceMetadataTags string `mapstructure:"instance_metadata_tags" required:"false"`
 }

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -146,7 +146,15 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	}
 
 	if s.HttpEndpoint == "enabled" {
-		runOpts.MetadataOptions = &ec2.InstanceMetadataOptionsRequest{HttpEndpoint: &s.HttpEndpoint, HttpTokens: &s.HttpTokens, HttpPutResponseHopLimit: &s.HttpPutResponseHopLimit, InstanceMetadataTags: &s.InstanceMetadataTags}
+		runOpts.MetadataOptions = &ec2.InstanceMetadataOptionsRequest{
+			HttpEndpoint:            &s.HttpEndpoint,
+			HttpTokens:              &s.HttpTokens,
+			HttpPutResponseHopLimit: &s.HttpPutResponseHopLimit,
+		}
+	}
+
+	if s.InstanceMetadataTags == "enabled" {
+		runOpts.MetadataOptions.InstanceMetadataTags = aws.String(s.InstanceMetadataTags)
 	}
 
 	// Collect tags for tagging on resource creation

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -148,7 +148,15 @@ func (s *StepRunSpotInstance) CreateTemplateData(userData *string, az string,
 	}
 
 	if s.HttpEndpoint == "enabled" {
-		templateData.MetadataOptions = &ec2.LaunchTemplateInstanceMetadataOptionsRequest{HttpEndpoint: &s.HttpEndpoint, HttpTokens: &s.HttpTokens, HttpPutResponseHopLimit: &s.HttpPutResponseHopLimit, InstanceMetadataTags: &s.InstanceMetadataTags}
+		templateData.MetadataOptions = &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
+			HttpEndpoint:            &s.HttpEndpoint,
+			HttpTokens:              &s.HttpTokens,
+			HttpPutResponseHopLimit: &s.HttpPutResponseHopLimit,
+		}
+	}
+
+	if s.InstanceMetadataTags == "enabled" {
+		templateData.MetadataOptions.InstanceMetadataTags = aws.String(s.InstanceMetadataTags)
 	}
 
 	// If instance type is not set, we'll just pick the lowest priced instance

--- a/builder/common/step_run_spot_instance_test.go
+++ b/builder/common/step_run_spot_instance_test.go
@@ -366,7 +366,7 @@ func TestRun_NoSpotTags(t *testing.T) {
 	}
 
 	if action != multistep.ActionContinue {
-		t.Fatalf("shoul continue, but: %v", action)
+		t.Fatalf("should continue, but: %v", action)
 	}
 
 	if len(ec2Mock.CreateLaunchTemplateParams[0].TagSpecifications) != 0 {

--- a/docs-partials/builder/common/MetadataOptions-not-required.mdx
+++ b/docs-partials/builder/common/MetadataOptions-not-required.mdx
@@ -10,6 +10,7 @@
   Defaults to 1.
 
 - `instance_metadata_tags` (string) - A string to enable or disable access to instance tags from the instance metadata. Defaults to disabled.
+  Access to instance metadata tags is available for commercial regions. For non-commercial regions please check availability before enabling.
   Accepts either "enabled" or "disabled"
 
 <!-- End of code generated from the comments of the MetadataOptions struct in builder/common/run_config.go; -->


### PR DESCRIPTION
The ability to include instance tags within the instance metadata
service is not supported for non-commercial regions such as GovCloud.
This change will only include the configuration for instances metadata
tags when enabled. By default, where supported, unspecified settings
will use the default API value of "disabled". Enabling support for tags
in a unsupported region will result in an AWS launch error, which will
terminate the build.

Closes #242
