### PR TITLE
[bugfix] Allow Enable-Deprecation on copied or encrypted AMIs

### DIFF
--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -370,10 +370,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Tags:               b.config.RunTags,
 			Ctx:                b.config.ctx,
 		},
-		&stepEnableDeprecation{
-			DeprecationTime:    b.config.DeprecationTime,
-			AMISkipCreateImage: b.config.AMISkipCreateImage,
-		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:       &b.config.AccessConfig,
 			Regions:            b.config.AMIRegions,
@@ -384,6 +380,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			OriginalRegion:     *ec2conn.Config.Region,
 			AMISkipCreateImage: b.config.AMISkipCreateImage,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+		},
+		&stepEnableDeprecation{
+			DeprecationTime:    b.config.DeprecationTime,
+			AMISkipCreateImage: b.config.AMISkipCreateImage,
 		},
 		&awscommon.StepModifyAMIAttributes{
 			AMISkipCreateImage: b.config.AMISkipCreateImage,


### PR DESCRIPTION
This PR fixes #249.
Looking at the general order of steps in `ebs/builder.go`, I noticed that enabling deprecation was done _before_ copying the AMI to other regions and/or encrypting said AMI's. Since EC2's `CopyImage` request does not copy the deprecation attribute, these steps should be switched.

It also seems to make more sense, since `StepModifyAMIAttributes` and `StepCreateTags` were also executed _after_ the Region Copy step.
