### PR TITLE
Add `enable_nitro_enclave` argument to enable support for Nitro Enclaves on instance

### DIFF
--- a/builder/common/run_config_test.go
+++ b/builder/common/run_config_test.go
@@ -307,3 +307,37 @@ func TestRunConfigPrepare_TenancyGood(t *testing.T) {
 		}
 	}
 }
+
+func TestRunConfigPrepare_EnableNitroEnclaveBadWithSpotInstanceRequest(t *testing.T) {
+	c := testConfig()
+	// Nitro Enclaves cannot be used with Spot Instances
+	c.InstanceType = "c5.xlarge"
+	c.EnableNitroEnclave = true
+	c.SpotPrice = "auto"
+	err := c.Prepare(nil)
+	if len(err) != 1 {
+		t.Fatalf("Should error if Nitro Enclaves has been used in conjuntion with a Spot Price request")
+	}
+}
+
+func TestRunConfigPrepare_EnableNitroEnclaveBadWithBurstableInstanceType(t *testing.T) {
+	c := testConfig()
+	// Nitro Enclaves cannot be used with burstable instances
+	c.InstanceType = "t2.micro"
+	c.EnableNitroEnclave = true
+	err := c.Prepare(nil)
+	if len(err) != 1 {
+		t.Fatalf("Should error if Nitro Enclaves has been used in conjuntion with a burstable instance type")
+	}
+}
+
+func TestRunConfigPrepare_EnableNitroEnclaveGood(t *testing.T) {
+	c := testConfig()
+	// Nitro Enclaves cannot be used with burstable instances
+	c.InstanceType = "c5.xlarge"
+	c.EnableNitroEnclave = true
+	err := c.Prepare(nil)
+	if len(err) != 0 {
+		t.Fatalf("Should not error with valid Nitro Enclave config")
+	}
+}

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -46,6 +46,7 @@ type StepRunSourceInstance struct {
 	UserDataFile                      string
 	VolumeTags                        map[string]string
 	NoEphemeral                       bool
+	EnableNitroEnclave                bool
 
 	instanceId string
 }
@@ -109,6 +110,10 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		return multistep.ActionHalt
 	}
 
+	enclaveOptions := ec2.EnclaveOptionsRequest{
+		Enabled: &s.EnableNitroEnclave,
+	}
+
 	az := state.Get("availability_zone").(string)
 	runOpts := &ec2.RunInstancesInput{
 		ImageId:             &s.SourceAMI,
@@ -120,6 +125,7 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		BlockDeviceMappings: s.LaunchMappings.BuildEC2BlockDeviceMappings(),
 		Placement:           &ec2.Placement{AvailabilityZone: &az},
 		EbsOptimized:        &s.EbsOptimized,
+		EnclaveOptions:      &enclaveOptions,
 	}
 
 	if s.NoEphemeral {

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -238,6 +238,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			EnableNitroEnclave:                b.config.EnableNitroEnclave,
 			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
 			ExpectedRootDevice:                "ebs",
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -65,6 +65,7 @@ type FlatConfig struct {
 	BlockDurationMinutes                      *int64                                 `mapstructure:"block_duration_minutes" required:"false" cty:"block_duration_minutes" hcl:"block_duration_minutes"`
 	DisableStopInstance                       *bool                                  `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
+	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
@@ -223,6 +224,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"block_duration_minutes":        &hcldec.AttrSpec{Name: "block_duration_minutes", Type: cty.Number, Required: false},
 		"disable_stop_instance":         &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
+		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -265,6 +265,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			EnableNitroEnclave:                b.config.EnableNitroEnclave,
 			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
 			ExpectedRootDevice:                "ebs",
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -86,6 +86,7 @@ type FlatConfig struct {
 	BlockDurationMinutes                      *int64                                 `mapstructure:"block_duration_minutes" required:"false" cty:"block_duration_minutes" hcl:"block_duration_minutes"`
 	DisableStopInstance                       *bool                                  `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
+	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
@@ -244,6 +245,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"block_duration_minutes":        &hcldec.AttrSpec{Name: "block_duration_minutes", Type: cty.Number, Required: false},
 		"disable_stop_instance":         &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
+		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -230,6 +230,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Ctx:                               b.config.ctx,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			EnableNitroEnclave:                b.config.EnableNitroEnclave,
 			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
 			ExpectedRootDevice:                "ebs",
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,

--- a/builder/ebsvolume/builder.hcl2spec.go
+++ b/builder/ebsvolume/builder.hcl2spec.go
@@ -98,6 +98,7 @@ type FlatConfig struct {
 	BlockDurationMinutes                      *int64                                 `mapstructure:"block_duration_minutes" required:"false" cty:"block_duration_minutes" hcl:"block_duration_minutes"`
 	DisableStopInstance                       *bool                                  `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
+	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
@@ -230,6 +231,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"block_duration_minutes":        &hcldec.AttrSpec{Name: "block_duration_minutes", Type: cty.Number, Required: false},
 		"disable_stop_instance":         &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
+		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -211,11 +211,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			errs, fmt.Errorf("x509_key_path points to bad file: %s", err))
 	}
 
-	if b.config.IsSpotInstance() && ((b.config.AMIENASupport.True()) || b.config.AMISriovNetSupport) {
+	if b.config.IsSpotInstance() && ((b.config.AMIENASupport.True()) || b.config.AMISriovNetSupport || b.config.EnableNitroEnclave) {
 		errs = packersdk.MultiErrorAppend(errs,
 			fmt.Errorf("Spot instances do not support modification, which is required "+
-				"when either `ena_support` or `sriov_support` are set. Please ensure "+
-				"you use an AMI that already has either SR-IOV or ENA enabled."))
+				"when either `ena_support`, `sriov_support`, or `enable_nitro_enclave` "+
+				"are set. Please ensure you use an AMI that already has either SR-IOV "+
+				"or ENA enabled."))
 	}
 
 	if b.config.RunConfig.SpotPriceAutoProduct != "" {
@@ -298,6 +299,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Ctx:                      b.config.ctx,
 			Debug:                    b.config.PackerDebug,
 			EbsOptimized:             b.config.EbsOptimized,
+			EnableNitroEnclave:       b.config.EnableNitroEnclave,
 			EnableT2Unlimited:        b.config.EnableT2Unlimited,
 			InstanceType:             b.config.InstanceType,
 			IsRestricted:             b.config.IsChinaCloud(),

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -65,6 +65,7 @@ type FlatConfig struct {
 	BlockDurationMinutes                      *int64                                 `mapstructure:"block_duration_minutes" required:"false" cty:"block_duration_minutes" hcl:"block_duration_minutes"`
 	DisableStopInstance                       *bool                                  `mapstructure:"disable_stop_instance" required:"false" cty:"disable_stop_instance" hcl:"disable_stop_instance"`
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
+	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
@@ -227,6 +228,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"block_duration_minutes":        &hcldec.AttrSpec{Name: "block_duration_minutes", Type: cty.Number, Required: false},
 		"disable_stop_instance":         &hcldec.AttrSpec{Name: "disable_stop_instance", Type: cty.Bool, Required: false},
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
+		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -43,6 +43,10 @@
   Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).
   Default `false`.
 
+- `enable_nitro_enclave` (bool) - Enable support for Nitro Enclaves on the instance.  Note that the instance type must
+  be able to [support Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/faqs/).
+  This option is not supported for spot instances.
+
 - `enable_t2_unlimited` (bool) - Enabling T2 Unlimited allows the source instance to burst additional CPU
   beyond its available [CPU
   Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)


### PR DESCRIPTION
Adds support for enabling Nitro Enclaves on instance.  An example config would be: 

```
source "amazon-ebs" "example" {
    enable_nitro_enclave = true
}
```

Closes #245 


