### PR TITLE
Create fix for deprecation of images in other regions

### DIFF
--- a/builder/common/step_enable_deprecation.go
+++ b/builder/common/step_enable_deprecation.go
@@ -1,28 +1,29 @@
-package ebs
+package common
 
 import (
 	"context"
 	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-type stepEnableDeprecation struct {
+type StepEnableDeprecation struct {
+	AccessConfig       *AccessConfig
 	DeprecationTime    string
 	AMISkipCreateImage bool
 }
 
-func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepEnableDeprecation) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	if s.AMISkipCreateImage || s.DeprecationTime == "" {
 		ui.Say("Skipping Enable AMI deprecation...")
 		return multistep.ActionContinue
 	}
 
-	ec2conn := state.Get("ec2").(*ec2.EC2)
 	amis, ok := state.Get("amis").(map[string]string)
 	if !ok {
 		err := fmt.Errorf("no AMIs found in state to deprecate")
@@ -32,13 +33,27 @@ func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBa
 	}
 
 	deprecationTime, _ := time.Parse(time.RFC3339, s.DeprecationTime)
-	for _, ami := range amis {
+	for region, ami := range amis {
+
+		session, err := s.AccessConfig.Session()
+		if err != nil {
+			err := fmt.Errorf("Error getting region %s connection for deprecation: %s", region, err)
+			state.Put("error", err)
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+
+		regionconn := ec2.New(session.Copy(&aws.Config{
+			Region: aws.String(region),
+		}))
+
 		ui.Say(fmt.Sprintf("Enabling deprecation on AMI (%s)...", ami))
 
-		_, err := ec2conn.EnableImageDeprecation(&ec2.EnableImageDeprecationInput{
+		_, err = regionconn.EnableImageDeprecation(&ec2.EnableImageDeprecationInput{
 			ImageId:     &ami,
 			DeprecateAt: &deprecationTime,
 		})
+
 		if err != nil {
 			err := fmt.Errorf("Error enable AMI deprecation: %s", err)
 			state.Put("error", err)
@@ -48,6 +63,6 @@ func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBa
 	}
 	return multistep.ActionContinue
 }
-func (s *stepEnableDeprecation) Cleanup(state multistep.StateBag) {
+func (s *StepEnableDeprecation) Cleanup(state multistep.StateBag) {
 	// No cleanup...
 }

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -382,7 +382,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			AMISkipCreateImage: b.config.AMISkipCreateImage,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 		},
-		&stepEnableDeprecation{
+		&awscommon.StepEnableDeprecation{
 			DeprecationTime:    b.config.DeprecationTime,
 			AMISkipCreateImage: b.config.AMISkipCreateImage,
 		},


### PR DESCRIPTION
These changes should fix the crash that occurs when enabling deprecation while also copying images to other regions.

Closes #259 

This PR is still a work-in-progress