### PR TITLE
Update Plugin binary releases to match Packer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,38 @@ builds:
       - amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
   -
+    id: linux-builds
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: linux
+        goarch: amd64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+  -
+    id: darwin-builds
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath #removes all file system paths from the compiled executable
+    ldflags:
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
+  -
+    id: other-builds
     mod_timestamp: '{{ .CommitTimestamp }}'
     flags:
       - -trimpath #removes all file system paths from the compiled executable
@@ -34,24 +66,21 @@ builds:
       - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     goos:
       - netbsd
-      - solaris
       - openbsd
       - freebsd
       - windows
-      - linux
-      - darwin
+      - solaris
     goarch:
       - amd64
       - '386'
       - arm
-      - arm64
     ignore:
-      - goos: openbsd
-        goarch: arm64
-      - goos: darwin
+      - goos: windows
+        goarch: arm
+      - goos: solaris
+        goarch: arm
+      - goos: solaris
         goarch: '386'
-      - goos: linux
-        goarch: amd64
     binary: '{{ .ProjectName }}_v{{ .Version }}_{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 archives:
 - format: zip


### PR DESCRIPTION
The goreleaser binary release matrix has been updated to match the binaries platforms distributed by Packer core. A complete list of supported binaries can be found at https://releases.hashicorp.com/packer/1.8.3

- darwin/amd64
- darwin/arm64
- freebsd/386
- freebsd/amd64
- freebsd/arm
- linux/386
- linux/amd64
- linux/arm
- linux/arm64
- netbsd/386
- netbsd/amd64
- netbsd/arm
- openbsd/386
- openbsd/amd64
- openbsd/arm
- windows/386
- windows/amd64
- solaris/amd64
