### PR TITLE
version: cut version for 1.1.4

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,12 +4,12 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.1.3"
+	Version = "1.1.4"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.


### PR DESCRIPTION
Release version 1.1.4 of the Amazon plugin

