### PR TITLE
Add support for `uefi_data` in builders

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -199,6 +199,9 @@ type Config struct {
 	// more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
 	// `uefi` when `ami_architecture` is `arm64`.
 	BootMode string `mapstructure:"boot_mode" required:"false"`
+	// Base64 representation of the non-volatile UEFI variable store. For more information
+	// see [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/uefi-secure-boot-optionB.html).
+	UefiData string `mapstructure:"uefi_data" required:"false"`
 	// Enforce version of the Instance Metadata Service on the built AMI.
 	// Valid options are unset (legacy) and `v2.0`. See the documentation on
 	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
@@ -511,6 +514,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 			PollingConfig:            b.config.PollingConfig,
 			BootMode:                 b.config.BootMode,
+			UefiData:                 b.config.UefiData,
 			IMDSSupport:              b.config.IMDSSupport,
 		},
 		&awscommon.StepAMIRegionCopy{

--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -395,6 +395,15 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		}
 	}
 
+	if b.config.UefiData != "" {
+		if b.config.BootMode == "legacy-bios" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`You can't use uefi_data with boot_mode set to "legacy-bios".`))
+		} else if b.config.BootMode == "" && b.config.Architecture != "arm64" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`You need boot_mode set to "uefi" to use uefi_data, `+
+				`"%s" architecture defaults to "legacy-bios".`, b.config.Architecture))
+		}
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}

--- a/builder/chroot/builder.hcl2spec.go
+++ b/builder/chroot/builder.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	RootVolumeKmsKeyId      *string                           `mapstructure:"root_volume_kms_key_id" required:"false" cty:"root_volume_kms_key_id" hcl:"root_volume_kms_key_id"`
 	Architecture            *string                           `mapstructure:"ami_architecture" required:"false" cty:"ami_architecture" hcl:"ami_architecture"`
 	BootMode                *string                           `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
+	UefiData                *string                           `mapstructure:"uefi_data" required:"false" cty:"uefi_data" hcl:"uefi_data"`
 	IMDSSupport             *string                           `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
 }
 
@@ -169,6 +170,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"root_volume_kms_key_id":        &hcldec.AttrSpec{Name: "root_volume_kms_key_id", Type: cty.String, Required: false},
 		"ami_architecture":              &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
 		"boot_mode":                     &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
+		"uefi_data":                     &hcldec.AttrSpec{Name: "uefi_data", Type: cty.String, Required: false},
 		"imds_support":                  &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/chroot/builder_test.go
+++ b/builder/chroot/builder_test.go
@@ -210,6 +210,52 @@ func TestBuilderPrepare_RootDeviceNameNoAMIMappings(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_UefiData(t *testing.T) {
+	var b Builder
+	config := testConfig()
+
+	// Test bad
+	config["uefi_data"] = "foo"
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test good
+	config["ami_architecture"] = "arm64"
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	// Test bad
+	config["boot_mode"] = "legacy-bios"
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test good
+	config["ami_architecture"] = "x86_64"
+	config["boot_mode"] = "uefi"
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
 func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 	var b Builder
 	config := testConfig()

--- a/builder/chroot/builder_test.go
+++ b/builder/chroot/builder_test.go
@@ -211,48 +211,59 @@ func TestBuilderPrepare_RootDeviceNameNoAMIMappings(t *testing.T) {
 }
 
 func TestBuilderPrepare_UefiData(t *testing.T) {
-	var b Builder
-	config := testConfig()
+	tests := []struct {
+		name         string
+		bootMode     string
+		uefiData     string
+		architecture string
+		expectError  bool
+	}{
+		{
+			name:        "OK - boot mode set to uefi",
+			uefiData:    "foo",
+			bootMode:    "uefi",
+			expectError: false,
+		},
+		{
+			name:        "Error - boot mode set to legacy-bios",
+			uefiData:    "foo",
+			bootMode:    "legacy-bios",
+			expectError: true,
+		},
+		{
+			name:        "Error - default boot mode is legacy-bios",
+			uefiData:    "foo",
+			expectError: true,
+		},
+		{
+			name:         "OK - default boot mode for arm64 is uefi",
+			uefiData:     "foo",
+			architecture: "arm64",
+			expectError:  false,
+		},
+	}
 
-	// Test bad
-	config["uefi_data"] = "foo"
-	_, warnings, err := b.Prepare(config)
-	if len(warnings) > 0 {
-		t.Fatalf("bad: %#v", warnings)
-	}
-	if err == nil {
-		t.Fatal("should have error")
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := testConfig()
+			config["uefi_data"] = tt.uefiData
+			config["boot_mode"] = tt.bootMode
+			config["ami_architecture"] = tt.architecture
 
-	// Test good
-	config["ami_architecture"] = "arm64"
-	_, warnings, err = b.Prepare(config)
-	if len(warnings) > 0 {
-		t.Fatalf("bad: %#v", warnings)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
-	}
+			b := &Builder{}
 
-	// Test bad
-	config["boot_mode"] = "legacy-bios"
-	_, warnings, err = b.Prepare(config)
-	if len(warnings) > 0 {
-		t.Fatalf("bad: %#v", warnings)
-	}
-	if err == nil {
-		t.Fatal("should have error")
-	}
+			_, _, err := b.Prepare(config)
+			if err != nil && !tt.expectError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Fatalf("expected an error, got a success instead")
+			}
 
-	// Test good
-	config["ami_architecture"] = "x86_64"
-	config["boot_mode"] = "uefi"
-	_, warnings, err = b.Prepare(config)
-	if len(warnings) > 0 {
-		t.Fatalf("bad: %#v", warnings)
-	}
-	if err != nil {
-		t.Fatalf("should not have error: %s", err)
+			if err != nil {
+				t.Logf("OK: b.Prepare produced expected error: %s", err)
+			}
+		})
 	}
 }
 

--- a/builder/chroot/step_register_ami.go
+++ b/builder/chroot/step_register_ami.go
@@ -21,6 +21,7 @@ type StepRegisterAMI struct {
 	EnableAMISriovNetSupport bool
 	AMISkipBuildRegion       bool
 	BootMode                 string
+	UefiData                 string
 	IMDSSupport              string
 }
 
@@ -71,6 +72,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	if s.BootMode != "" {
 		registerOpts.BootMode = aws.String(s.BootMode)
+	}
+	if s.UefiData != "" {
+		registerOpts.UefiData = aws.String(s.UefiData)
 	}
 	if s.IMDSSupport != "" {
 		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -202,6 +202,15 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		}
 	}
 
+	if b.config.UefiData != "" {
+		if b.config.BootMode == "legacy-bios" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`You can't use uefi_data with boot_mode set to "legacy-bios".`))
+		} else if b.config.BootMode == "" && b.config.Architecture != "arm64" {
+			errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`You need boot_mode set to "uefi" to use uefi_data, `+
+				`"%s" architecture defaults to "legacy-bios".`, b.config.Architecture))
+		}
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -75,6 +75,9 @@ type Config struct {
 	// more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
 	// `uefi` when `ami_architecture` is `arm64`.
 	BootMode string `mapstructure:"boot_mode" required:"false"`
+	// Base64 representation of the non-volatile UEFI variable store. For more information
+	// see [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/uefi-secure-boot-optionB.html).
+	UefiData string `mapstructure:"uefi_data" required:"false"`
 	// Enforce version of the Instance Metadata Service on the built AMI.
 	// Valid options are unset (legacy) and `v2.0`. See the documentation on
 	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
@@ -433,6 +436,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 			PollingConfig:            b.config.PollingConfig,
 			BootMode:                 b.config.BootMode,
+			UefiData:                 b.config.UefiData,
 			IMDSSupport:              b.config.IMDSSupport,
 		},
 		&awscommon.StepAMIRegionCopy{

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -207,6 +207,7 @@ type FlatConfig struct {
 	VolumeRunTag                              []config.FlatNameValue                 `mapstructure:"run_volume_tag" required:"false" cty:"run_volume_tag" hcl:"run_volume_tag"`
 	Architecture                              *string                                `mapstructure:"ami_architecture" required:"false" cty:"ami_architecture" hcl:"ami_architecture"`
 	BootMode                                  *string                                `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
+	UefiData                                  *string                                `mapstructure:"uefi_data" required:"false" cty:"uefi_data" hcl:"uefi_data"`
 	IMDSSupport                               *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
 }
 
@@ -372,6 +373,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"run_volume_tag":               &hcldec.BlockListSpec{TypeName: "run_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatNameValue)(nil).HCL2Spec())},
 		"ami_architecture":             &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
 		"boot_mode":                    &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
+		"uefi_data":                    &hcldec.AttrSpec{Name: "uefi_data", Type: cty.String, Required: false},
 		"imds_support":                 &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/ebssurrogate/builder_test.go
+++ b/builder/ebssurrogate/builder_test.go
@@ -57,6 +57,67 @@ func TestBuilderPrepare_InvalidKey(t *testing.T) {
 	}
 }
 
+func TestBuilderPrepare_UefiData(t *testing.T) {
+	var b Builder
+	// Basic configuration
+	b.config.RootDevice = RootBlockDevice{
+		SourceDeviceName: "device name",
+		DeviceName:       "device name",
+	}
+	b.config.LaunchMappings = BlockDevices{
+		BlockDevice{
+			BlockDevice: common.BlockDevice{
+				DeviceName: "device name",
+			},
+			OmitFromArtifact: false,
+		},
+	}
+	b.config.AMIVirtType = "type"
+	config := testConfig()
+	config["ami_name"] = "name"
+
+	// Test bad
+	config["uefi_data"] = "foo"
+	_, warnings, err := b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test good
+	config["ami_architecture"] = "arm64"
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+
+	// Test bad
+	config["boot_mode"] = "legacy-bios"
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err == nil {
+		t.Fatal("should have error")
+	}
+
+	// Test good
+	config["ami_architecture"] = "x86_64"
+	config["boot_mode"] = "uefi"
+	_, warnings, err = b.Prepare(config)
+	if len(warnings) > 0 {
+		t.Fatalf("bad: %#v", warnings)
+	}
+	if err != nil {
+		t.Fatalf("should not have error: %s", err)
+	}
+}
+
 func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 	var b Builder
 	// Basic configuration

--- a/builder/ebssurrogate/step_register_ami.go
+++ b/builder/ebssurrogate/step_register_ami.go
@@ -26,6 +26,7 @@ type StepRegisterAMI struct {
 	LaunchOmitMap            map[string]bool
 	AMISkipBuildRegion       bool
 	BootMode                 string
+	UefiData                 string
 	IMDSSupport              string
 }
 
@@ -76,6 +77,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	if s.BootMode != "" {
 		registerOpts.BootMode = aws.String(s.BootMode)
+	}
+	if s.UefiData != "" {
+		registerOpts.UefiData = aws.String(s.UefiData)
 	}
 	if s.IMDSSupport != "" {
 		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)

--- a/docs-partials/builder/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/chroot/Config-not-required.mdx
@@ -159,6 +159,9 @@
   more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
   `uefi` when `ami_architecture` is `arm64`.
 
+- `uefi_data` (string) - Base64 representation of the non-volatile UEFI variable store. For more information
+  see [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/uefi-secure-boot-optionB.html).
+
 - `imds_support` (string) - Enforce version of the Instance Metadata Service on the built AMI.
   Valid options are unset (legacy) and `v2.0`. See the documentation on
   [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)

--- a/docs-partials/builder/ebssurrogate/Config-not-required.mdx
+++ b/docs-partials/builder/ebssurrogate/Config-not-required.mdx
@@ -35,6 +35,9 @@
   more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
   `uefi` when `ami_architecture` is `arm64`.
 
+- `uefi_data` (string) - Base64 representation of the non-volatile UEFI variable store. For more information
+  see [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/uefi-secure-boot-optionB.html).
+
 - `imds_support` (string) - Enforce version of the Instance Metadata Service on the built AMI.
   Valid options are unset (legacy) and `v2.0`. See the documentation on
   [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)


### PR DESCRIPTION
Add support for `uefi_data` to register an AMI with a pre-populated UEFI variable store.
This is necessary for Secure Boot and to use custom UEFI boot entries.
Such variable stores can be created with https://github.com/awslabs/python-uefivars, by using the `aws` format the base64 encoded variable store can be passed to `uefi_data`.

Available for chroot and ebssurrogate builders which use `RegisterImage` and support `boot_mode`.

Closes #253