### PR TITLE
Add support for toggling unlimited credits for T3/T3a/T4g instance type

### DIFF
--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -177,10 +177,12 @@ type RunConfig struct {
 	// up a [Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-standard-mode.html)
 	// instance instead.
 	//
-	// To use Unlimited you must use a T2/T3/T4g instance type, e.g. (`t2.micro`, `t3.micro`).
+	// To use Unlimited you must use a T2/T3/T3a/T4g instance type, e.g. (`t2.micro`, `t3.micro`).
 	// Additionally, Unlimited cannot be used in conjunction with Spot
-	// Instances, e.g. when the `spot_price` option has been configured.
-	// Attempting to do so will cause an error.
+	// Instances for T2 type instances, e.g. when the `spot_price` option has been configured.
+	// Attempting to do so will cause an error if the underlying instance type is a T2 type instance.
+	// By default the supported burstable instance types (including t3/t3a/t4g) will be provisioned with its cpu credits set to standard,
+	// only when `enable_unlimited_credits` is true will the instance be provisioned with unlimited cpu credits.
 	EnableUnlimitedCredits bool `mapstructure:"enable_unlimited_credits" required:"false"`
 	// The name of an [IAM instance
 	// profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -134,6 +134,7 @@ type RunConfig struct {
 	// be able to [support Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/faqs/).
 	// This option is not supported for spot instances.
 	EnableNitroEnclave bool `mapstructure:"enable_nitro_enclave" required:"false"`
+	// Deprecated argument - please use "enable_unlimited_credits".
 	// Enabling T2 Unlimited allows the source instance to burst additional CPU
 	// beyond its available [CPU
 	// Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
@@ -157,6 +158,24 @@ type RunConfig struct {
 	// Unlimited - even for instances that would usually qualify for the
 	// [AWS Free Tier](https://aws.amazon.com/free/).
 	EnableT2Unlimited bool `mapstructure:"enable_t2_unlimited" required:"false"`
+	// Enabling Unlimited credits allows the source instance to burst additional CPU
+	// beyond its available [CPU
+	// Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-unlimited-mode-concepts.html#unlimited-mode-surplus-credits)
+	// for as long as the demand exists. This is in contrast to the standard
+	// configuration that only allows an instance to consume up to its
+	// available CPU Credits. See the AWS documentation for [T2
+	// Unlimited](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-unlimited-mode-concepts.html)
+	// and the **Unlimited Pricing** section of the [Amazon EC2 On-Demand
+	// Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for
+	// more information. By default this option is disabled and Packer will set
+	// up a [Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-standard-mode.html)
+	// instance instead.
+	//
+	// To use Unlimited you must use a T2/T3/T4g instance type, e.g. (`t2.micro`, `t3.micro`).
+	// Additionally, Unlimited cannot be used in conjunction with Spot
+	// Instances, e.g. when the `spot_price` option has been configured.
+	// Attempting to do so will cause an error.
+	EnableUnlimitedCredits bool `mapstructure:"enable_unlimited_credits" required:"false"`
 	// The name of an [IAM instance
 	// profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
 	// to launch the EC2 instance with.
@@ -614,8 +633,6 @@ type RunConfig struct {
 }
 
 func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
-	// Validation
-	errs := c.Comm.Prepare(ctx)
 
 	// If we are not given an explicit ssh_keypair_name or
 	// ssh_private_key_file, then create a temporary one, but only if the
@@ -639,6 +656,14 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 	if c.RunTags == nil {
 		c.RunTags = make(map[string]string)
 	}
+
+	// EnableT2Unlimited has been deprecated so we preserve any config settings.
+	if c.EnableT2Unlimited && !c.EnableUnlimitedCredits {
+		c.EnableUnlimitedCredits = c.EnableT2Unlimited
+	}
+
+	// Validation
+	errs := c.Comm.Prepare(ctx)
 
 	if c.Metadata.HttpEndpoint == "" {
 		c.Metadata.HttpEndpoint = "enabled"
@@ -795,15 +820,13 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		errs = append(errs, fmt.Errorf("shutdown_behavior only accepts 'stop' or 'terminate' values."))
 	}
 
-	if c.EnableT2Unlimited {
+	if c.EnableUnlimitedCredits {
 		if c.SpotPrice != "" {
-			errs = append(errs, fmt.Errorf("Error: T2 Unlimited cannot be used in conjunction with Spot Instances"))
+			errs = append(errs, fmt.Errorf("Error: Unlimited credits cannot be used in conjunction with Spot Instances"))
 		}
-		firstDotIndex := strings.Index(c.InstanceType, ".")
-		if firstDotIndex == -1 {
-			errs = append(errs, fmt.Errorf("Error determining main Instance Type from: %s", c.InstanceType))
-		} else if c.InstanceType[0:firstDotIndex] != "t2" {
-			errs = append(errs, fmt.Errorf("Error: T2 Unlimited enabled with a non-T2 Instance Type: %s", c.InstanceType))
+
+		if !c.IsBurstableInstanceType() {
+			errs = append(errs, fmt.Errorf("Error: Instance Type: %s is not within the supported types for Unlimited credits. Supported instance types are T2, T3, and T4g", c.InstanceType))
 		}
 	}
 
@@ -846,4 +869,11 @@ func (c *RunConfig) IsSpotInstance() bool {
 func (c *RunConfig) SSMAgentEnabled() bool {
 	hasIamInstanceProfile := c.IamInstanceProfile != "" || c.TemporaryIamInstanceProfilePolicyDocument != nil
 	return c.SSHInterface == "session_manager" && hasIamInstanceProfile
+}
+
+// IsBurstableInstanceType checks if the InstanceType for the config is one
+// of the following types T2, T3a, T3, T4g
+func (c *RunConfig) IsBurstableInstanceType() bool {
+	r := `^t(:?2|3a?|4g)\.`
+	return regexp.MustCompile(r).MatchString(c.InstanceType)
 }

--- a/builder/common/run_config_test.go
+++ b/builder/common/run_config_test.go
@@ -128,6 +128,54 @@ func TestRunConfigPrepare_EnableT2UnlimitedBadWithSpotInstanceRequest(t *testing
 	}
 }
 
+func TestRunConfigPrepare_EnableT2UnlimitedDeprecation(t *testing.T) {
+	c := testConfig()
+	// Must have a T2 instance type if T2 Unlimited is enabled
+	c.InstanceType = "t2.micro"
+	c.EnableT2Unlimited = true
+	err := c.Prepare(nil)
+
+	if c.EnableUnlimitedCredits != true {
+		t.Errorf("expected EnableUnlimitedCredits to be true when the deprecated EnableT2Unlimited is true, but got %T", c.EnableUnlimitedCredits)
+	}
+
+	if len(err) > 0 {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestRunConfigPrepare_EnableUnlimitedCredits(t *testing.T) {
+
+	tc := []struct {
+		name          string
+		instanceType  string
+		enableCredits bool
+		errorCount    int
+	}{
+		{"T2 instance", "t2.micro", true, 0},
+		{"T3 instance", "t3.micro", true, 0},
+		{"T3a instance", "t3a.xlarge", true, 0},
+		{"T4g instance", "t4g.micro", true, 0},
+		{"M5 instance", "m5.micro", true, 1},
+		{"bogus t4 instance", "t4.micro", true, 1},
+		{"bogus t23 instance", "t23.micro", true, 1},
+	}
+
+	for _, tt := range tc {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			c := testConfig()
+			c.InstanceType = tt.instanceType
+			c.EnableUnlimitedCredits = tt.enableCredits
+			err := c.Prepare(nil)
+			if len(err) != tt.errorCount {
+				t.Errorf("err: %s", err)
+			}
+
+		})
+	}
+}
+
 func TestRunConfigPrepare_SpotAuto(t *testing.T) {
 	c := testConfig()
 	c.SpotPrice = "auto"

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -149,13 +149,11 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	}
 
 	if s.IsBurstableInstanceType {
-		creditOption := "standard"
-		runOpts.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: &creditOption}
+		runOpts.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: aws.String(CPUCreditsStandard)}
 	}
 
 	if s.EnableUnlimitedCredits {
-		creditOption := "unlimited"
-		runOpts.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: &creditOption}
+		runOpts.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: aws.String(CPUCreditsUnlimited)}
 	}
 
 	if s.HttpEndpoint == "enabled" {

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -28,7 +28,7 @@ type StepRunSourceInstance struct {
 	Ctx                               interpolate.Context
 	Debug                             bool
 	EbsOptimized                      bool
-	EnableT2Unlimited                 bool
+	EnableUnlimitedCredits            bool
 	ExpectedRootDevice                string
 	HttpEndpoint                      string
 	HttpTokens                        string
@@ -47,6 +47,7 @@ type StepRunSourceInstance struct {
 	VolumeTags                        map[string]string
 	NoEphemeral                       bool
 	EnableNitroEnclave                bool
+	IsBurstableInstanceType           bool
 
 	instanceId string
 }
@@ -147,7 +148,12 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		}
 	}
 
-	if s.EnableT2Unlimited {
+	if s.IsBurstableInstanceType {
+		creditOption := "standard"
+		runOpts.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: &creditOption}
+	}
+
+	if s.EnableUnlimitedCredits {
 		creditOption := "unlimited"
 		runOpts.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: &creditOption}
 	}

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -53,6 +53,8 @@ type StepRunSpotInstance struct {
 	UserDataFile                      string
 	Ctx                               interpolate.Context
 	NoEphemeral                       bool
+	IsBurstableInstanceType           bool
+	EnableUnlimitedCredits            bool
 
 	instanceId string
 }
@@ -146,6 +148,14 @@ func (s *StepRunSpotInstance) CreateTemplateData(userData *string, az string,
 	} else {
 		templateData.SetSecurityGroupIds(securityGroupIds)
 
+	}
+
+	if s.IsBurstableInstanceType {
+		templateData.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: aws.String(CPUCreditsStandard)}
+	}
+
+	if s.EnableUnlimitedCredits {
+		templateData.CreditSpecification = &ec2.CreditSpecificationRequest{CpuCredits: aws.String(CPUCreditsUnlimited)}
 	}
 
 	if s.HttpEndpoint == "enabled" {

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -206,6 +206,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Comm:                              &b.config.RunConfig.Comm,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			IsBurstableInstanceType:           b.config.RunConfig.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:            b.config.EnableUnlimitedCredits,
 			ExpectedRootDevice:                "ebs",
 			FleetTags:                         b.config.FleetTags,
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -156,6 +156,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			"understand how Packer requests Spot instances.")
 	}
 
+	if b.config.RunConfig.EnableT2Unlimited {
+		warns = append(warns, "enable_t2_unlimited is deprecated please use "+
+			"enable_unlimited_credits. In future versions of "+
+			"Packer, inclusion of enable_t2_unlimited will error your builds.")
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}
@@ -239,7 +245,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
 			EnableNitroEnclave:                b.config.EnableNitroEnclave,
-			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
+			IsBurstableInstanceType:           b.config.RunConfig.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:            b.config.EnableUnlimitedCredits,
 			ExpectedRootDevice:                "ebs",
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,
 			HttpTokens:                        b.config.Metadata.HttpTokens,

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -67,6 +67,7 @@ type FlatConfig struct {
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
 	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
+	EnableUnlimitedCredits                    *bool                                  `mapstructure:"enable_unlimited_credits" required:"false" cty:"enable_unlimited_credits" hcl:"enable_unlimited_credits"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
 	FleetTag                                  []config.FlatKeyValue                  `mapstructure:"fleet_tag" required:"false" cty:"fleet_tag" hcl:"fleet_tag"`
@@ -227,6 +228,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
 		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
+		"enable_unlimited_credits":      &hcldec.AttrSpec{Name: "enable_unlimited_credits", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},
 		"fleet_tag":                     &hcldec.BlockListSpec{TypeName: "fleet_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -770,6 +770,40 @@ func TestAccBuilder_EbsKeyPair_rsaSHA2OnlyServer(t *testing.T) {
 	acctest.TestPlugin(t, testcase)
 }
 
+//go:embed test-fixtures/unlimited-credits/burstable_instances.pkr.hcl
+var testBurstableInstanceTypes string
+
+func TestAccBuilder_EnableUnlimitedCredits(t *testing.T) {
+	testcase := &acctest.PluginTestCase{
+		Name:     "amazon-ebs_unlimited_credits_test",
+		Template: testBurstableInstanceTypes,
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState.ExitCode() != 0 {
+				return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+			}
+			return nil
+		},
+	}
+	acctest.TestPlugin(t, testcase)
+}
+
+//go:embed test-fixtures/unlimited-credits/burstable_spot_instances.pkr.hcl
+var testBurstableSpotInstanceTypes string
+
+func TestAccBuilder_EnableUnlimitedCredits_withSpotInstances(t *testing.T) {
+	testcase := &acctest.PluginTestCase{
+		Name:     "amazon-ebs_unlimited_credits_spot_instance_test",
+		Template: testBurstableSpotInstanceTypes,
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState.ExitCode() != 0 {
+				return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+			}
+			return nil
+		},
+	}
+	acctest.TestPlugin(t, testcase)
+}
+
 func testEC2Conn(region string) (*ec2.EC2, error) {
 	access := &common.AccessConfig{RawRegion: region}
 	session, err := access.Session()

--- a/builder/ebs/test-fixtures/unlimited-credits/burstable_instances.pkr.hcl
+++ b/builder/ebs/test-fixtures/unlimited-credits/burstable_instances.pkr.hcl
@@ -1,0 +1,86 @@
+variables {
+  standardCPUCredit  = "standard"
+  unlimitedCPUCredit = "unlimited"
+}
+
+variable "region" {
+ type    = string
+ default = "us-west-2"
+}
+
+source "amazon-ebs" "standard" {
+  region                  = var.region
+  source_ami              = "ami-044065b5480679567"
+  instance_type           = "t3.small"
+  ssh_username            = "ec2-user"
+  ssh_agent_auth          = false
+  temporary_key_pair_type = "ed25519"
+  ami_name                = "packer_AWS_{{timestamp}}"
+  skip_create_ami         = true
+  temporary_iam_instance_profile_policy_document {
+    Version = "2012-10-17"
+    Statement {
+      Effect = "Allow"
+      Action = [
+        "ec2:GetDefaultCreditSpecification",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceCreditSpecifications"
+      ]
+      Resource = ["*"]
+    }
+  }
+}
+
+
+source "amazon-ebs" "unlimited" {
+  region                   = var.region
+  source_ami               = "ami-044065b5480679567"
+  instance_type            = "t2.small"
+  ssh_username             = "ec2-user"
+  ssh_agent_auth           = false
+  enable_unlimited_credits = true
+  temporary_key_pair_type  = "ed25519"
+  ami_name                 = "packer_AWS_{{timestamp}}"
+  skip_create_ami          = true
+  temporary_iam_instance_profile_policy_document {
+    Version = "2012-10-17"
+    Statement {
+      Effect = "Allow"
+      Action = [
+        "ec2:GetDefaultCreditSpecification",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceCreditSpecifications"
+      ]
+      Resource = ["*"]
+    }
+  }
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.standard",
+    "source.amazon-ebs.unlimited"
+  ]
+  provisioner "shell" {
+    inline = ["sudo dnf install -q -y jq"]
+  }
+
+  provisioner "shell" {
+    only = ["amazon-ebs.standard"]
+    inline = [
+      "aws configure set region ${var.region} --profile default",
+      "CREDITTYPE=$(aws ec2 describe-instance-credit-specifications --instance-ids ${build.ID}| jq --raw-output \".InstanceCreditSpecifications|.[]|.CpuCredits\")",
+      "echo CPU Credit Specification is $CREDITTYPE",
+      "[[ $CREDITTYPE == ${var.standardCPUCredit} ]]"
+    ]
+  }
+  provisioner "shell" {
+    only = ["amazon-ebs.unlimited"]
+    inline = [
+      "aws configure set region ${var.region} --profile default",
+      "CREDITTYPE=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 describe-instance-credit-specifications --instance-ids ${build.ID} | jq --raw-output \".InstanceCreditSpecifications|.[]|.CpuCredits\")",
+      "echo CPU Credit Specification is $CREDITTYPE",
+      "[[ $CREDITTYPE == ${var.unlimitedCPUCredit} ]]"
+    ]
+  }
+}

--- a/builder/ebs/test-fixtures/unlimited-credits/burstable_spot_instances.pkr.hcl
+++ b/builder/ebs/test-fixtures/unlimited-credits/burstable_spot_instances.pkr.hcl
@@ -1,0 +1,83 @@
+variables {
+  standardCPUCredit  = "standard"
+  unlimitedCPUCredit = "unlimited"
+}
+
+variable "region" {
+ type    = string
+ default = "us-west-2"
+}
+
+source "amazon-ebs" "standard_spot" {
+  region                  = var.region
+  spot_price              = "auto"
+  source_ami              = "ami-044065b5480679567"
+  instance_type           = "t3a.nano"
+  ssh_username            = "ec2-user"
+  ami_name                = "packer_AWS_{{timestamp}}"
+  skip_create_ami         = true
+  temporary_iam_instance_profile_policy_document {
+    Version = "2012-10-17"
+    Statement {
+      Effect = "Allow"
+      Action = [
+        "ec2:GetDefaultCreditSpecification",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceCreditSpecifications"
+      ]
+      Resource = ["*"]
+    }
+  }
+}
+
+source "amazon-ebs" "unlimited_spot" {
+  region                   = var.region
+  spot_price               = "auto"
+  source_ami               = "ami-044065b5480679567"
+  instance_type            = "t3a.nano"
+  ssh_username             = "ec2-user"
+  enable_unlimited_credits = true
+  ami_name                 = "packer_AWS_{{timestamp}}"
+  skip_create_ami          = true
+  temporary_iam_instance_profile_policy_document {
+    Version = "2012-10-17"
+    Statement {
+      Effect = "Allow"
+      Action = [
+        "ec2:GetDefaultCreditSpecification",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceCreditSpecifications"
+      ]
+      Resource = ["*"]
+    }
+  }
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.standard_spot",
+    "source.amazon-ebs.unlimited_spot"
+  ]
+  provisioner "shell" {
+    inline = ["sudo dnf install -q -y jq"]
+  }
+
+  provisioner "shell" {
+    only = ["amazon-ebs.standard_spot"]
+    inline = [
+      "aws configure set region ${var.region} --profile default",
+      "CREDITTYPE=$(aws ec2 describe-instance-credit-specifications --instance-ids ${build.ID}| jq --raw-output \".InstanceCreditSpecifications|.[]|.CpuCredits\")",
+      "echo CPU Credit Specification is $CREDITTYPE",
+      "[[ $CREDITTYPE == ${var.standardCPUCredit} ]]"
+    ]
+  }
+  provisioner "shell" {
+    only = ["amazon-ebs.unlimited_spot"]
+    inline = [
+      "aws configure set region ${var.region} --profile default",
+      "CREDITTYPE=$(AWS_DEFAULT_REGION=us-west-2 aws ec2 describe-instance-credit-specifications --instance-ids ${build.ID} | jq --raw-output \".InstanceCreditSpecifications|.[]|.CpuCredits\")",
+      "echo CPU Credit Specification is $CREDITTYPE",
+      "[[ $CREDITTYPE == ${var.unlimitedCPUCredit} ]]"
+    ]
+  }
+}

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -157,6 +157,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			"understand how Packer requests Spot instances.")
 	}
 
+	if b.config.RunConfig.EnableT2Unlimited {
+		warns = append(warns, "enable_t2_unlimited is deprecated please use "+
+			"enable_unlimited_credits. In future versions of "+
+			"Packer, inclusion of enable_t2_unlimited will error your builds.")
+	}
+
 	if b.config.Architecture == "" {
 		b.config.Architecture = "x86_64"
 	}
@@ -266,7 +272,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
 			EnableNitroEnclave:                b.config.EnableNitroEnclave,
-			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
+			IsBurstableInstanceType:           b.config.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:            b.config.EnableUnlimitedCredits,
 			ExpectedRootDevice:                "ebs",
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,
 			HttpTokens:                        b.config.Metadata.HttpTokens,

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -234,6 +234,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Comm:                              &b.config.RunConfig.Comm,
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
+			IsBurstableInstanceType:           b.config.RunConfig.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:            b.config.EnableUnlimitedCredits,
 			ExpectedRootDevice:                "ebs",
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,
 			HttpTokens:                        b.config.Metadata.HttpTokens,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -88,6 +88,7 @@ type FlatConfig struct {
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
 	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
+	EnableUnlimitedCredits                    *bool                                  `mapstructure:"enable_unlimited_credits" required:"false" cty:"enable_unlimited_credits" hcl:"enable_unlimited_credits"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
 	FleetTag                                  []config.FlatKeyValue                  `mapstructure:"fleet_tag" required:"false" cty:"fleet_tag" hcl:"fleet_tag"`
@@ -248,6 +249,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
 		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
+		"enable_unlimited_credits":      &hcldec.AttrSpec{Name: "enable_unlimited_credits", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},
 		"fleet_tag":                     &hcldec.BlockListSpec{TypeName: "fleet_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -200,6 +200,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
 			ExpectedRootDevice:                "ebs",
+			IsBurstableInstanceType:           b.config.RunConfig.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:            b.config.EnableUnlimitedCredits,
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,
 			HttpTokens:                        b.config.Metadata.HttpTokens,
 			HttpPutResponseHopLimit:           b.config.Metadata.HttpPutResponseHopLimit,

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -152,6 +152,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			"understand how Packer requests Spot instances.")
 	}
 
+	if b.config.RunConfig.EnableT2Unlimited {
+		warns = append(warns, "enable_t2_unlimited is deprecated please use "+
+			"enable_unlimited_credits. In future versions of "+
+			"Packer, inclusion of enable_t2_unlimited will error your builds.")
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}
@@ -231,7 +237,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Debug:                             b.config.PackerDebug,
 			EbsOptimized:                      b.config.EbsOptimized,
 			EnableNitroEnclave:                b.config.EnableNitroEnclave,
-			EnableT2Unlimited:                 b.config.EnableT2Unlimited,
+			IsBurstableInstanceType:           b.config.RunConfig.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:            b.config.EnableUnlimitedCredits,
 			ExpectedRootDevice:                "ebs",
 			HttpEndpoint:                      b.config.Metadata.HttpEndpoint,
 			HttpTokens:                        b.config.Metadata.HttpTokens,

--- a/builder/ebsvolume/builder.hcl2spec.go
+++ b/builder/ebsvolume/builder.hcl2spec.go
@@ -100,6 +100,7 @@ type FlatConfig struct {
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
 	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
+	EnableUnlimitedCredits                    *bool                                  `mapstructure:"enable_unlimited_credits" required:"false" cty:"enable_unlimited_credits" hcl:"enable_unlimited_credits"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
 	FleetTag                                  []config.FlatKeyValue                  `mapstructure:"fleet_tag" required:"false" cty:"fleet_tag" hcl:"fleet_tag"`
@@ -234,6 +235,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
 		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
+		"enable_unlimited_credits":      &hcldec.AttrSpec{Name: "enable_unlimited_credits", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},
 		"fleet_tag":                     &hcldec.BlockListSpec{TypeName: "fleet_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -227,6 +227,12 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			"understand how Packer requests Spot instances.")
 	}
 
+	if b.config.RunConfig.EnableT2Unlimited {
+		warns = append(warns, "enable_t2_unlimited is deprecated please use "+
+			"enable_unlimited_credits. In future versions of "+
+			"Packer, inclusion of enable_t2_unlimited will error your builds.")
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}
@@ -300,7 +306,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Debug:                    b.config.PackerDebug,
 			EbsOptimized:             b.config.EbsOptimized,
 			EnableNitroEnclave:       b.config.EnableNitroEnclave,
-			EnableT2Unlimited:        b.config.EnableT2Unlimited,
+			IsBurstableInstanceType:  b.config.RunConfig.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:   b.config.EnableUnlimitedCredits,
 			InstanceType:             b.config.InstanceType,
 			IsRestricted:             b.config.IsChinaCloud(),
 			SourceAMI:                b.config.SourceAmi,

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -275,6 +275,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Comm:                     &b.config.RunConfig.Comm,
 			Debug:                    b.config.PackerDebug,
 			EbsOptimized:             b.config.EbsOptimized,
+			IsBurstableInstanceType:  b.config.RunConfig.IsBurstableInstanceType(),
+			EnableUnlimitedCredits:   b.config.EnableUnlimitedCredits,
 			InstanceType:             b.config.InstanceType,
 			FleetTags:                b.config.FleetTags,
 			Region:                   *ec2conn.Config.Region,

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -67,6 +67,7 @@ type FlatConfig struct {
 	EbsOptimized                              *bool                                  `mapstructure:"ebs_optimized" required:"false" cty:"ebs_optimized" hcl:"ebs_optimized"`
 	EnableNitroEnclave                        *bool                                  `mapstructure:"enable_nitro_enclave" required:"false" cty:"enable_nitro_enclave" hcl:"enable_nitro_enclave"`
 	EnableT2Unlimited                         *bool                                  `mapstructure:"enable_t2_unlimited" required:"false" cty:"enable_t2_unlimited" hcl:"enable_t2_unlimited"`
+	EnableUnlimitedCredits                    *bool                                  `mapstructure:"enable_unlimited_credits" required:"false" cty:"enable_unlimited_credits" hcl:"enable_unlimited_credits"`
 	IamInstanceProfile                        *string                                `mapstructure:"iam_instance_profile" required:"false" cty:"iam_instance_profile" hcl:"iam_instance_profile"`
 	FleetTags                                 map[string]string                      `mapstructure:"fleet_tags" required:"false" cty:"fleet_tags" hcl:"fleet_tags"`
 	FleetTag                                  []config.FlatKeyValue                  `mapstructure:"fleet_tag" required:"false" cty:"fleet_tag" hcl:"fleet_tag"`
@@ -231,6 +232,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"ebs_optimized":                 &hcldec.AttrSpec{Name: "ebs_optimized", Type: cty.Bool, Required: false},
 		"enable_nitro_enclave":          &hcldec.AttrSpec{Name: "enable_nitro_enclave", Type: cty.Bool, Required: false},
 		"enable_t2_unlimited":           &hcldec.AttrSpec{Name: "enable_t2_unlimited", Type: cty.Bool, Required: false},
+		"enable_unlimited_credits":      &hcldec.AttrSpec{Name: "enable_unlimited_credits", Type: cty.Bool, Required: false},
 		"iam_instance_profile":          &hcldec.AttrSpec{Name: "iam_instance_profile", Type: cty.String, Required: false},
 		"fleet_tags":                    &hcldec.AttrSpec{Name: "fleet_tags", Type: cty.Map(cty.String), Required: false},
 		"fleet_tag":                     &hcldec.BlockListSpec{TypeName: "fleet_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -84,10 +84,12 @@
   up a [Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-standard-mode.html)
   instance instead.
   
-  To use Unlimited you must use a T2/T3/T4g instance type, e.g. (`t2.micro`, `t3.micro`).
+  To use Unlimited you must use a T2/T3/T3a/T4g instance type, e.g. (`t2.micro`, `t3.micro`).
   Additionally, Unlimited cannot be used in conjunction with Spot
-  Instances, e.g. when the `spot_price` option has been configured.
-  Attempting to do so will cause an error.
+  Instances for T2 type instances, e.g. when the `spot_price` option has been configured.
+  Attempting to do so will cause an error if the underlying instance type is a T2 type instance.
+  By default the supported burstable instance types (including t3/t3a/t4g) will be provisioned with its cpu credits set to standard,
+  only when `enable_unlimited_credits` is true will the instance be provisioned with unlimited cpu credits.
 
 - `iam_instance_profile` (string) - The name of an [IAM instance
   profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -47,7 +47,8 @@
   be able to [support Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/faqs/).
   This option is not supported for spot instances.
 
-- `enable_t2_unlimited` (bool) - Enabling T2 Unlimited allows the source instance to burst additional CPU
+- `enable_t2_unlimited` (bool) - Deprecated argument - please use "enable_unlimited_credits".
+  Enabling T2 Unlimited allows the source instance to burst additional CPU
   beyond its available [CPU
   Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html)
   for as long as the demand exists. This is in contrast to the standard
@@ -69,6 +70,24 @@
   !&gt; **Warning!** Additional costs may be incurred by enabling T2
   Unlimited - even for instances that would usually qualify for the
   [AWS Free Tier](https://aws.amazon.com/free/).
+
+- `enable_unlimited_credits` (bool) - Enabling Unlimited credits allows the source instance to burst additional CPU
+  beyond its available [CPU
+  Credits](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-unlimited-mode-concepts.html#unlimited-mode-surplus-credits)
+  for as long as the demand exists. This is in contrast to the standard
+  configuration that only allows an instance to consume up to its
+  available CPU Credits. See the AWS documentation for [T2
+  Unlimited](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-unlimited-mode-concepts.html)
+  and the **Unlimited Pricing** section of the [Amazon EC2 On-Demand
+  Pricing](https://aws.amazon.com/ec2/pricing/on-demand/) document for
+  more information. By default this option is disabled and Packer will set
+  up a [Standard](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/burstable-performance-instances-standard-mode.html)
+  instance instead.
+  
+  To use Unlimited you must use a T2/T3/T4g instance type, e.g. (`t2.micro`, `t3.micro`).
+  Additionally, Unlimited cannot be used in conjunction with Spot
+  Instances, e.g. when the `spot_price` option has been configured.
+  Attempting to do so will cause an error.
 
 - `iam_instance_profile` (string) - The name of an [IAM instance
   profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/instance-profiles.html)
@@ -401,7 +420,7 @@
   specified.
 
 - `temporary_security_group_source_public_ip` (bool) - When enabled, use public IP of the host (obtained from https://checkip.amazonaws.com)
-  as IPv4 CIDR block to be authorized access to the instance, when packer
+  as CIDR block to be authorized access to the instance, when packer
   is creating a temporary security group. Defaults to `false`.
   
   This is only used when `security_group_id`, `security_group_ids`,


### PR DESCRIPTION
- Add support to toggle unlimited credits for t3 and t4g instance types.
- Add deprecation warning for EnableT2Unlimited to all builders
- Add test validating EnableUnlimitedCredits is true when EnableT2Unlimited is true
- Update default credit type to standard for all burstable instance types
- Add EnableUnlimitedCredits for spot instance type builds
- Update StepRunSourceInstance to use CPUCredits const values
- Add acceptance test for enable_unlimited_credits


Closes #127 