### PR TITLE
Add support for configurating IMDSv2 as the default instance metadata service

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -199,6 +199,11 @@ type Config struct {
 	// more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
 	// `uefi` when `ami_architecture` is `arm64`.
 	BootMode string `mapstructure:"boot_mode" required:"false"`
+	// Enforce version of the Instance Metadata Service on the built AMI.
+	// Valid options are unset (legacy) and `v2.0`. See the documentation on
+	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+	// for more information. Defaults to legacy.
+	IMDSSupport string `mapstructure:"imds_support" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -502,6 +507,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 			PollingConfig:            b.config.PollingConfig,
 			BootMode:                 b.config.BootMode,
+			IMDSSupport:              b.config.IMDSSupport,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,

--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -375,6 +375,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid ami_architecture values are "arm64", "i386", "x86_64", or "x86_64_mac"`))
 	}
 
+	if b.config.IMDSSupport != "" && b.config.IMDSSupport != ec2.ImdsSupportValuesV20 {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid imds_support values are %q or the empty string`, ec2.ImdsSupportValuesV20))
+	}
+
 	if b.config.BootMode != "" {
 		valid := false
 		for _, validBootMode := range []string{"legacy-bios", "uefi"} {

--- a/builder/chroot/builder.hcl2spec.go
+++ b/builder/chroot/builder.hcl2spec.go
@@ -83,6 +83,7 @@ type FlatConfig struct {
 	RootVolumeKmsKeyId      *string                           `mapstructure:"root_volume_kms_key_id" required:"false" cty:"root_volume_kms_key_id" hcl:"root_volume_kms_key_id"`
 	Architecture            *string                           `mapstructure:"ami_architecture" required:"false" cty:"ami_architecture" hcl:"ami_architecture"`
 	BootMode                *string                           `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
+	IMDSSupport             *string                           `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -168,6 +169,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"root_volume_kms_key_id":        &hcldec.AttrSpec{Name: "root_volume_kms_key_id", Type: cty.String, Required: false},
 		"ami_architecture":              &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
 		"boot_mode":                     &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
+		"imds_support":                  &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/chroot/builder_test.go
+++ b/builder/chroot/builder_test.go
@@ -249,3 +249,53 @@ func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 		t.Fatalf("Generated data should contain MountPath")
 	}
 }
+
+func TestBuilderPrepare_IMDSSupportValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		optValue    string
+		expectError bool
+	}{
+		{
+			name:        "OK - no value set",
+			optValue:    "",
+			expectError: false,
+		},
+		{
+			name:        "OK - v2.0",
+			optValue:    "v2.0",
+			expectError: false,
+		},
+		{
+			name:        "Error - bad value set",
+			optValue:    "v3.0",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := testConfig()
+			config["ami_name"] = "name"
+			config["root_device_name"] = "/dev/sda"
+			config["ami_block_device_mappings"] = []interface{}{map[string]string{}}
+			config["root_volume_size"] = 15
+
+			config["imds_support"] = tt.optValue
+
+			b := &Builder{}
+
+			_, _, err := b.Prepare(config)
+			if err != nil && !tt.expectError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Fatalf("expected an error, got a success instead")
+			}
+
+			if err != nil {
+				t.Logf("OK: b.Prepare produced expected error: %s", err)
+			}
+		})
+	}
+}

--- a/builder/chroot/step_register_ami.go
+++ b/builder/chroot/step_register_ami.go
@@ -21,6 +21,7 @@ type StepRegisterAMI struct {
 	EnableAMISriovNetSupport bool
 	AMISkipBuildRegion       bool
 	BootMode                 string
+	IMDSSupport              string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -71,6 +72,10 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	if s.BootMode != "" {
 		registerOpts.BootMode = aws.String(s.BootMode)
 	}
+	if s.IMDSSupport != "" {
+		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)
+	}
+
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
 	if err != nil {
 		state.Put("error", fmt.Errorf("Error registering AMI: %s", err))

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -182,6 +182,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid ami_architecture values are "arm64", "i386", "x86_64", or "x86_64_mac"`))
 	}
 
+	if b.config.IMDSSupport != "" && b.config.IMDSSupport != ec2.ImdsSupportValuesV20 {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid imds_support values are %q or the empty string`, ec2.ImdsSupportValuesV20))
+	}
+
 	if b.config.BootMode != "" {
 		valid := false
 		for _, validBootMode := range []string{"legacy-bios", "uefi"} {

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -75,9 +75,10 @@ type Config struct {
 	// more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
 	// `uefi` when `ami_architecture` is `arm64`.
 	BootMode string `mapstructure:"boot_mode" required:"false"`
-	// Default version of the Instance Metadata Service. Valid options are unset (legacy) and
-	// `v2.0`. See the documentation on [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
-	// for more information. Defaults to unset.
+	// Enforce version of the Instance Metadata Service on the built AMI.
+	// Valid options are unset (legacy) and `v2.0`. See the documentation on
+	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+	// for more information. Defaults to legacy.
 	IMDSSupport string `mapstructure:"imds_support" required:"false"`
 
 	ctx interpolate.Context
@@ -425,6 +426,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 			PollingConfig:            b.config.PollingConfig,
 			BootMode:                 b.config.BootMode,
+			IMDSSupport:              b.config.IMDSSupport,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:       &b.config.AccessConfig,

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -75,6 +75,10 @@ type Config struct {
 	// more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
 	// `uefi` when `ami_architecture` is `arm64`.
 	BootMode string `mapstructure:"boot_mode" required:"false"`
+	// Default version of the Instance Metadata Service. Valid options are unset (legacy) and
+	// `v2.0`. See the documentation on [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+	// for more information. Defaults to unset.
+	IMDSSupport string `mapstructure:"imds_support" required:"false"`
 
 	ctx interpolate.Context
 }

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -204,6 +204,7 @@ type FlatConfig struct {
 	VolumeRunTag                              []config.FlatNameValue                 `mapstructure:"run_volume_tag" required:"false" cty:"run_volume_tag" hcl:"run_volume_tag"`
 	Architecture                              *string                                `mapstructure:"ami_architecture" required:"false" cty:"ami_architecture" hcl:"ami_architecture"`
 	BootMode                                  *string                                `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
+	IMDSSupport                               *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -365,6 +366,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"run_volume_tag":               &hcldec.BlockListSpec{TypeName: "run_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatNameValue)(nil).HCL2Spec())},
 		"ami_architecture":             &hcldec.AttrSpec{Name: "ami_architecture", Type: cty.String, Required: false},
 		"boot_mode":                    &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
+		"imds_support":                 &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/ebssurrogate/builder_acc_test.go
+++ b/builder/ebssurrogate/builder_acc_test.go
@@ -1,0 +1,129 @@
+package ebssurrogate
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	amazon_acc "github.com/hashicorp/packer-plugin-amazon/builder/ebs/acceptance"
+	"github.com/hashicorp/packer-plugin-sdk/acctest"
+)
+
+func TestAccBuilder_EbssurrogateBasic(t *testing.T) {
+	ami := amazon_acc.AMIHelper{
+		Region: "us-east-1",
+		Name:   "ebs-basic-acc-test",
+	}
+	testCase := &acctest.PluginTestCase{
+		Name:     "amazon-ebssurrogate_basic_test",
+		Template: fmt.Sprintf(testBuilderAccBasic, ami.Name),
+		Teardown: func() error {
+			return ami.CleanUpAmi()
+		},
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState != nil {
+				if buildCommand.ProcessState.ExitCode() != 0 {
+					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+				}
+			}
+			return nil
+		},
+	}
+	acctest.TestPlugin(t, testCase)
+}
+
+func TestAccBuilder_EbssurrogateBasic_forceIMDSv2(t *testing.T) {
+	ami := amazon_acc.AMIHelper{
+		Region: "us-east-1",
+		Name:   "ebs-basic-acc-test-imdsv2",
+	}
+	testCase := &acctest.PluginTestCase{
+		Name:     "amazon-ebssurrogate_basic_test_imdsv2",
+		Template: fmt.Sprintf(testBuilderAccBasicIMDSv2, ami.Name),
+		Teardown: func() error {
+			return ami.CleanUpAmi()
+		},
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState != nil {
+				if buildCommand.ProcessState.ExitCode() != 0 {
+					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+				}
+			}
+
+			images, err := ami.GetAmi()
+			if err != nil {
+				return fmt.Errorf("failed to get AMI %q: %s", ami.Name, err)
+			}
+
+			if len(images) != 1 {
+				return fmt.Errorf("expected 1 image, got %d", len(images))
+			}
+
+			img := images[0]
+
+			if img.ImdsSupport != nil && *img.ImdsSupport != "v2.0" {
+				return fmt.Errorf("expected AMI to have IMDSv2 support, got %q", *img.ImdsSupport)
+			}
+
+			return nil
+		},
+	}
+	acctest.TestPlugin(t, testCase)
+}
+
+const testBuilderAccBasic = `
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}
+`
+
+const testBuilderAccBasicIMDSv2 = `
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	imds_support = "v2.0"
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}
+`

--- a/builder/ebssurrogate/builder_test.go
+++ b/builder/ebssurrogate/builder_test.go
@@ -108,3 +108,63 @@ func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 		t.Fatalf("Generated data should contain SourceAMIOwnerName")
 	}
 }
+
+func TestBuilderPrepare_IMDSSupportValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		optValue    string
+		expectError bool
+	}{
+		{
+			name:        "OK - no value set",
+			optValue:    "",
+			expectError: false,
+		},
+		{
+			name:        "OK - v2.0",
+			optValue:    "v2.0",
+			expectError: false,
+		},
+		{
+			name:        "Error - bad value set",
+			optValue:    "v3.0",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := testConfig()
+			config["ami_name"] = "name"
+			config["ami_virtualization_type"] = "kvm"
+			config["imds_support"] = tt.optValue
+
+			b := &Builder{}
+			// Basic configuration
+			b.config.RootDevice = RootBlockDevice{
+				SourceDeviceName: "device name",
+				DeviceName:       "device name",
+			}
+			b.config.LaunchMappings = BlockDevices{
+				BlockDevice{
+					BlockDevice: common.BlockDevice{
+						DeviceName: "device name",
+					},
+					OmitFromArtifact: false,
+				},
+			}
+
+			_, _, err := b.Prepare(config)
+			if err != nil && !tt.expectError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Fatalf("expected an error, got a success instead")
+			}
+
+			if err != nil {
+				t.Logf("OK: b.Prepare produced expected error: %s", err)
+			}
+		})
+	}
+}

--- a/builder/ebssurrogate/step_register_ami.go
+++ b/builder/ebssurrogate/step_register_ami.go
@@ -26,6 +26,7 @@ type StepRegisterAMI struct {
 	LaunchOmitMap            map[string]bool
 	AMISkipBuildRegion       bool
 	BootMode                 string
+	IMDSSupport              string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -75,6 +76,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	if s.BootMode != "" {
 		registerOpts.BootMode = aws.String(s.BootMode)
+	}
+	if s.IMDSSupport != "" {
+		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)
 	}
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
 	if err != nil {

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -88,6 +88,11 @@ type Config struct {
 	// okay to create this directory as part of the provisioning process.
 	// Defaults to /tmp.
 	X509UploadPath string `mapstructure:"x509_upload_path" required:"false"`
+	// Enforce version of the Instance Metadata Service on the built AMI.
+	// Valid options are unset (legacy) and `v2.0`. See the documentation on
+	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+	// for more information. Defaults to legacy.
+	IMDSSupport string `mapstructure:"imds_support" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -427,6 +432,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			EnableAMIENASupport:      b.config.AMIENASupport,
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 			PollingConfig:            b.config.PollingConfig,
+			IMDSSupport:              b.config.IMDSSupport,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -238,6 +238,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			"Packer, inclusion of enable_t2_unlimited will error your builds.")
 	}
 
+	if b.config.IMDSSupport != "" && b.config.IMDSSupport != ec2.ImdsSupportValuesV20 {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid imds_support values are %q or the empty string`, ec2.ImdsSupportValuesV20))
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -163,6 +163,7 @@ type FlatConfig struct {
 	X509CertPath                              *string                                `mapstructure:"x509_cert_path" required:"true" cty:"x509_cert_path" hcl:"x509_cert_path"`
 	X509KeyPath                               *string                                `mapstructure:"x509_key_path" required:"true" cty:"x509_key_path" hcl:"x509_key_path"`
 	X509UploadPath                            *string                                `mapstructure:"x509_upload_path" required:"false" cty:"x509_upload_path" hcl:"x509_upload_path"`
+	IMDSSupport                               *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -328,6 +329,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"x509_cert_path":               &hcldec.AttrSpec{Name: "x509_cert_path", Type: cty.String, Required: false},
 		"x509_key_path":                &hcldec.AttrSpec{Name: "x509_key_path", Type: cty.String, Required: false},
 		"x509_upload_path":             &hcldec.AttrSpec{Name: "x509_upload_path", Type: cty.String, Required: false},
+		"imds_support":                 &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/instance/builder_test.go
+++ b/builder/instance/builder_test.go
@@ -341,3 +341,51 @@ func TestBuilderPrepare_ReturnGeneratedData(t *testing.T) {
 		t.Fatalf("Generated data should contain SourceAMIOwnerName")
 	}
 }
+
+func TestBuilderPrepare_IMDSSupportValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		optValue    string
+		expectError bool
+	}{
+		{
+			name:        "OK - no value set",
+			optValue:    "",
+			expectError: false,
+		},
+		{
+			name:        "OK - v2.0",
+			optValue:    "v2.0",
+			expectError: false,
+		},
+		{
+			name:        "Error - bad value set",
+			optValue:    "v3.0",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config, _ := testConfig()
+			config["ami_name"] = "name"
+			config["skip_region_validation"] = true
+
+			config["imds_support"] = tt.optValue
+
+			b := &Builder{}
+
+			_, _, err := b.Prepare(config)
+			if err != nil && !tt.expectError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Fatalf("expected an error, got a success instead")
+			}
+
+			if err != nil {
+				t.Logf("OK: b.Prepare produced expected error: %s", err)
+			}
+		})
+	}
+}

--- a/builder/instance/step_register_ami.go
+++ b/builder/instance/step_register_ami.go
@@ -18,6 +18,7 @@ type StepRegisterAMI struct {
 	EnableAMIENASupport      confighelper.Trilean
 	EnableAMISriovNetSupport bool
 	AMISkipBuildRegion       bool
+	IMDSSupport              string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -64,6 +65,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 		// Set EnaSupport to true
 		// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
 		registerOpts.EnaSupport = aws.Bool(true)
+	}
+	if s.IMDSSupport != "" {
+		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/docs-partials/builder/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/chroot/Config-not-required.mdx
@@ -159,4 +159,9 @@
   more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
   `uefi` when `ami_architecture` is `arm64`.
 
+- `imds_support` (string) - Enforce version of the Instance Metadata Service on the built AMI.
+  Valid options are unset (legacy) and `v2.0`. See the documentation on
+  [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+  for more information. Defaults to legacy.
+
 <!-- End of code generated from the comments of the Config struct in builder/chroot/builder.go; -->

--- a/docs-partials/builder/ebssurrogate/Config-not-required.mdx
+++ b/docs-partials/builder/ebssurrogate/Config-not-required.mdx
@@ -35,8 +35,9 @@
   more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
   `uefi` when `ami_architecture` is `arm64`.
 
-- `imds_support` (string) - Default version of the Instance Metadata Service. Valid options are unset (legacy) and
-  `v2.0`. See the documentation on [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
-  for more information. Defaults to unset.
+- `imds_support` (string) - Enforce version of the Instance Metadata Service on the built AMI.
+  Valid options are unset (legacy) and `v2.0`. See the documentation on
+  [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+  for more information. Defaults to legacy.
 
 <!-- End of code generated from the comments of the Config struct in builder/ebssurrogate/builder.go; -->

--- a/docs-partials/builder/ebssurrogate/Config-not-required.mdx
+++ b/docs-partials/builder/ebssurrogate/Config-not-required.mdx
@@ -35,4 +35,8 @@
   more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
   `uefi` when `ami_architecture` is `arm64`.
 
+- `imds_support` (string) - Default version of the Instance Metadata Service. Valid options are unset (legacy) and
+  `v2.0`. See the documentation on [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+  for more information. Defaults to unset.
+
 <!-- End of code generated from the comments of the Config struct in builder/ebssurrogate/builder.go; -->

--- a/docs-partials/builder/instance/Config-not-required.mdx
+++ b/docs-partials/builder/instance/Config-not-required.mdx
@@ -37,4 +37,9 @@
   okay to create this directory as part of the provisioning process.
   Defaults to /tmp.
 
+- `imds_support` (string) - Enforce version of the Instance Metadata Service on the built AMI.
+  Valid options are unset (legacy) and `v2.0`. See the documentation on
+  [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
+  for more information. Defaults to legacy.
+
 <!-- End of code generated from the comments of the Config struct in builder/instance/builder.go; -->

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/packer-plugin-amazon
 go 1.17
 
 require (
-	github.com/aws/aws-sdk-go v1.42.29
+	github.com/aws/aws-sdk-go v1.44.110
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/aws-sdk-go-base v0.7.1
 	github.com/hashicorp/go-cleanhttp v0.5.2
@@ -14,7 +14,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/stretchr/testify v1.7.0
 	github.com/zclconf/go-cty v1.10.0
-	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
 )
 
 require (
@@ -77,9 +77,9 @@ require (
 	github.com/ulikunitz/xz v0.5.10 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
-	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/api v0.56.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/aws/aws-sdk-go v1.30.8/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.40.34/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.42.29 h1:7nR+Ls5GGw1ZglG6YOfLzI8kDSy8didom/pLsb/K0fc=
-github.com/aws/aws-sdk-go v1.42.29/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
+github.com/aws/aws-sdk-go v1.44.110 h1:unno3l2FYQo6p0wYCp9gUk8YNzhOxqSktM0Y1vukl9k=
+github.com/aws/aws-sdk-go v1.44.110/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -662,8 +662,8 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
-golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -756,11 +756,13 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Add support for enabling IMDSv2 by default by using the new `imds_support` configuration option.

Closes #277 

---
Open issues/items:
- [ ] Add examples?
- [ ] Add unit tests?
- [ ] Run acceptance tests
