### PR TITLE
Update RunConfig-not-required.mdx

### DIFF
--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -113,7 +113,7 @@
   	Statement {
   		Action   = ["logs:*"]
   		Effect   = "Allow"
-  		Resource = "*"
+  		Resource = ["*"]
   	}
   	Version = "2012-10-17"
   }
@@ -129,7 +129,7 @@
   			"logs:*"
   			],
   			"Effect": "Allow",
-  			"Resource": "*"
+  			"Resource": ["*"]
   		}
   	]
   }


### PR DESCRIPTION
'Resource' field should be list of strings as per [builder/common/run_config.go](https://github.com/hashicorp/packer-plugin-amazon/blob/main/builder/common/run_config.go#L42)