### PR TITLE
Add missing closing brace in post-processor manifest example

### DIFF
--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -424,7 +424,8 @@ build {
     output = "manifest.json"
     strip_path = true
     custom_data = {
-    source_ami_name = "${build.SourceAMIName}"
+      source_ami_name = "${build.SourceAMIName}"
+    }
   }
 }
 ```


### PR DESCRIPTION
This PR fixes a small typo in the documentation, where an example was missing a closing brace.
