### PR TITLE
session_manager: Upload user public key to instance before connection if private key is specified

### DIFF
--- a/builder/common/step_create_ssm_tunnel.go
+++ b/builder/common/step_create_ssm_tunnel.go
@@ -3,13 +3,18 @@ package common
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2instanceconnect"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	pssm "github.com/hashicorp/packer-plugin-amazon/builder/common/ssm"
+	"github.com/hashicorp/packer-plugin-sdk/communicator"
+	"github.com/hashicorp/packer-plugin-sdk/communicator/sshkey"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	"github.com/hashicorp/packer-plugin-sdk/net"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -21,6 +26,7 @@ type StepCreateSSMTunnel struct {
 	LocalPortNumber  int
 	RemotePortNumber int
 	SSMAgentEnabled  bool
+	SSHConfig        *communicator.SSH
 	PauseBeforeSSM   time.Duration
 	stopSSMCommand   func()
 }
@@ -81,7 +87,47 @@ func (s *StepCreateSSMTunnel) Run(ctx context.Context, state multistep.StateBag)
 		}
 	}()
 
+	if len(s.SSHConfig.SSHPrivateKey) != 0 {
+		ui.Say("Uploading SSH public key to instance")
+		err := s.sendUserSSHPublicKey(instance, s.SSHConfig.SSHPrivateKey)
+		if err != nil {
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+	}
+
 	return multistep.ActionContinue
+}
+
+func (s *StepCreateSSMTunnel) sendUserSSHPublicKey(
+	instance *ec2.Instance,
+	privateKey []byte,
+) error {
+	publicKey, err := sshkey.PublicKeyFromPrivate(privateKey)
+	if err != nil {
+		return fmt.Errorf("Error getting public key from private key: %s", err)
+	}
+	svc := ec2instanceconnect.New(s.AWSSession)
+	input := &ec2instanceconnect.SendSSHPublicKeyInput{
+		AvailabilityZone: aws.String(*instance.Placement.AvailabilityZone),
+		InstanceId:       aws.String(*instance.InstanceId),
+		InstanceOSUser:   aws.String(s.SSHConfig.SSHUsername),
+		SSHPublicKey:     aws.String(strings.TrimSuffix(string(publicKey), "\n")),
+	}
+	log.Printf("Sending public key to instance: %s", *input.InstanceId)
+	result, err := svc.SendSSHPublicKey(input)
+	if err != nil {
+		err := fmt.Errorf(`
+        error encountered in sending public key to instance: %s
+      Check the key type and length are valid in AWS API.
+      https://docs.aws.amazon.com/ec2-instance-connect/latest/APIReference/API_SendSSHPublicKey.html`, err)
+		return err
+	} else {
+		if *result.Success {
+			return nil
+		}
+	}
+	return fmt.Errorf("Failed to send public key to instance")
 }
 
 // Cleanup terminates an active session on AWS, which in turn terminates the associated tunnel process running on the local machine.

--- a/builder/ebs/acceptance/utils.go
+++ b/builder/ebs/acceptance/utils.go
@@ -1,0 +1,22 @@
+package amazon_acc
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func GenerateSSHPrivateKeyFile() (string, error) {
+	outFile := fmt.Sprintf("%s/temp_key.ed25519", os.TempDir())
+	sshGenCmd := exec.Command("ssh-keygen", "-t", "ed25519", "-b", "256", "-f", outFile)
+	sshGenCmd.Stdin = bytes.NewBuffer([]byte("\n\n"))
+
+	_, err := sshGenCmd.CombinedOutput()
+	if err != nil {
+		os.Remove(outFile)
+		return "", err
+	}
+
+	return outFile, nil
+}

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -339,6 +339,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			LocalPortNumber:  b.config.SessionManagerPort,
 			RemotePortNumber: b.config.Comm.Port(),
 			SSMAgentEnabled:  b.config.SSMAgentEnabled(),
+			SSHConfig:        &b.config.Comm.SSH,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -771,6 +771,12 @@ func TestAccBuilder_EbsKeyPair_rsaSHA2OnlyServer(t *testing.T) {
 }
 
 func TestAccBuilder_PrivateKeyFile(t *testing.T) {
+	if os.Getenv(acctest.TestEnvVar) == "" {
+		t.Skipf("Acceptance tests skipped unless env '%s' set",
+			acctest.TestEnvVar)
+		return
+	}
+
 	ami := amazon_acc.AMIHelper{
 		Region: "us-east-1",
 		Name:   fmt.Sprintf("packer-pkey-file-acc-test-%d", time.Now().Unix()),

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -389,6 +389,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			LocalPortNumber:  b.config.SessionManagerPort,
 			RemotePortNumber: b.config.Comm.Port(),
 			SSMAgentEnabled:  b.config.SSMAgentEnabled(),
+			SSHConfig:        &b.config.Comm.SSH,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/ebssurrogate/builder_acc_test.go
+++ b/builder/ebssurrogate/builder_acc_test.go
@@ -2,8 +2,10 @@ package ebssurrogate
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	amazon_acc "github.com/hashicorp/packer-plugin-amazon/builder/ebs/acceptance"
 	"github.com/hashicorp/packer-plugin-sdk/acctest"
@@ -71,6 +73,33 @@ func TestAccBuilder_EbssurrogateBasic_forceIMDSv2(t *testing.T) {
 	acctest.TestPlugin(t, testCase)
 }
 
+func TestAccBuilder_Ebssurrogate_SSHPrivateKeyFile_SSM(t *testing.T) {
+	ami := amazon_acc.AMIHelper{
+		Region: "us-east-1",
+		Name:   fmt.Sprintf("packer-ebssurrogate-pkey-file-acc-test-%d", time.Now().Unix()),
+	}
+
+	sshFile, err := amazon_acc.GenerateSSHPrivateKeyFile()
+	if err != nil {
+		t.Fatalf("failed to generate SSH key file: %s", err)
+	}
+
+	defer os.Remove(sshFile)
+
+	testcase := &acctest.PluginTestCase{
+		Name:     "amazon-ebssurrogate_test_private_key_file",
+		Template: fmt.Sprintf(testPrivateKeyFile, ami.Name, sshFile),
+		Check: func(buildCommand *exec.Cmd, logfile string) error {
+			if buildCommand.ProcessState.ExitCode() != 0 {
+				return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
+			}
+			return nil
+		},
+	}
+
+	acctest.TestPlugin(t, testcase)
+}
+
 const testBuilderAccBasic = `
 source "amazon-ebssurrogate" "test" {
 	ami_name = "%s"
@@ -121,6 +150,38 @@ source "amazon-ebssurrogate" "test" {
 		volume_type = "gp2"
 	}
 	imds_support = "v2.0"
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}
+`
+
+const testPrivateKeyFile = `
+source "amazon-ebssurrogate" "test" {
+	ami_name             = "%s"
+	source_ami           = "ami-0b5eea76982371e91" # Amazon Linux 2 AMI - kernel 5.10
+	instance_type        = "m3.medium"
+	region               = "us-east-1"
+	ssh_username         = "ec2-user"
+	ssh_interface        = "session_manager"
+	iam_instance_profile = "SSMInstanceProfile"
+	communicator         = "ssh"
+	ssh_private_key_file = "%s"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
 }
 
 build {

--- a/builder/ebssurrogate/builder_acc_test.go
+++ b/builder/ebssurrogate/builder_acc_test.go
@@ -74,6 +74,12 @@ func TestAccBuilder_EbssurrogateBasic_forceIMDSv2(t *testing.T) {
 }
 
 func TestAccBuilder_Ebssurrogate_SSHPrivateKeyFile_SSM(t *testing.T) {
+	if os.Getenv(acctest.TestEnvVar) == "" {
+		t.Skipf("Acceptance tests skipped unless env '%s' set",
+			acctest.TestEnvVar)
+		return
+	}
+
 	ami := amazon_acc.AMIHelper{
 		Region: "us-east-1",
 		Name:   fmt.Sprintf("packer-ebssurrogate-pkey-file-acc-test-%d", time.Now().Unix()),

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -322,6 +322,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			LocalPortNumber:  b.config.SessionManagerPort,
 			RemotePortNumber: b.config.Comm.Port(),
 			SSMAgentEnabled:  b.config.SSMAgentEnabled(),
+			SSHConfig:        &b.config.Comm.SSH,
 		},
 		&communicator.StepConnect{
 			Config: &b.config.RunConfig.Comm,

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -397,6 +397,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			LocalPortNumber:  b.config.SessionManagerPort,
 			RemotePortNumber: b.config.Comm.Port(),
 			SSMAgentEnabled:  b.config.SSMAgentEnabled(),
+			SSHConfig:        &b.config.Comm.SSH,
 		},
 		&communicator.StepConnect{
 			// StepConnect is provided settings for WinRM and SSH, but


### PR DESCRIPTION
Improves SSM session manager feature by disabling key pair creation when user specifies a private key pair to be used.

The current implementation works fine for cases where the user does not specify a private key to be used with `session_manager`. In cases where the user specifies a private key, then that key will be used to authenticate but it fails since the key is not present on the EC2 instance.

This PR will resolve the issue by [sending the user public key](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2instanceconnect/#EC2InstanceConnect.SendSSHPublicKey) to the instance before connecting to it.

## The New Behavior

If the user does not specify a private key, then works like the previous implementations.

In the case where the user specifies a private key to be used:
1. key pair will not be created.
2. the public key will be sent to the instance before connecting to it. This key will live for 60 seconds which is enough for the handshake.

## Questions

There are some limitations to what public keys we can send to instances with SSM.
The SendSSHPublicKeyInput struct in aws-sdk-go currently used in the project only supports RSA keys because it has a limit on the length of the public key.
This behavior [is fixed](https://github.com/aws/aws-sdk-go/blob/main/service/ec2instanceconnect/api.go?rgh-link-date=2022-12-03T13%3A11%3A40Z#L651) in the recent version so if we update it then it supports other keys.

How can I update the docs?

I'll complete the code and add it to other builders once I get initial feedback on the implementation.

Closes #31