### PR TITLE
Fix spot instance launch readiness

### DIFF
--- a/builder/common/state.go
+++ b/builder/common/state.go
@@ -45,18 +45,22 @@ type StateChangeConf struct {
 //
 // HCL2 example:
 // ```hcl
-// aws_polling {
-//	 delay_seconds = 30
-//	 max_attempts = 50
-// }
+//
+//	aws_polling {
+//		 delay_seconds = 30
+//		 max_attempts = 50
+//	}
+//
 // ```
 //
 // JSON example:
 // ```json
-// "aws_polling" : {
-// 	 "delay_seconds": 30,
-// 	 "max_attempts": 50
-// }
+//
+//	"aws_polling" : {
+//		 "delay_seconds": 30,
+//		 "max_attempts": 50
+//	}
+//
 // ```
 type AWSPollingConfig struct {
 	// Specifies the maximum number of attempts the waiter will check for resource state.
@@ -99,7 +103,7 @@ func (w *AWSPollingConfig) WaitUntilAMIAvailable(ctx aws.Context, conn ec2iface.
 	return err
 }
 
-func (w *AWSPollingConfig) WaitUntilInstanceRunning(ctx aws.Context, conn *ec2.EC2, instanceId string) error {
+func (w *AWSPollingConfig) WaitUntilInstanceRunning(ctx aws.Context, conn ec2iface.EC2API, instanceId string) error {
 
 	instanceInput := ec2.DescribeInstancesInput{
 		InstanceIds: []*string{&instanceId},

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-amazon/builder/common/awserrors"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
@@ -202,7 +203,7 @@ func (s *StepRunSpotInstance) LoadUserData() (string, error) {
 }
 
 func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ec2conn := state.Get("ec2").(*ec2.EC2)
+	ec2conn := state.Get("ec2").(ec2iface.EC2API)
 	ui := state.Get("ui").(packersdk.Ui)
 
 	ui.Say("Launching a spot AWS instance...")

--- a/builder/common/step_run_spot_instance_test.go
+++ b/builder/common/step_run_spot_instance_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
@@ -180,6 +181,10 @@ func (m *runSpotEC2ConnMock) DescribeInstances(req *ec2.DescribeInstancesInput) 
 	} else {
 		return nil, nil
 	}
+}
+
+func (m *runSpotEC2ConnMock) WaitUntilInstanceRunningWithContext(ctx context.Context, _ *ec2.DescribeInstancesInput, opts ...request.WaiterOption) error {
+	return nil
 }
 
 func (m *runSpotEC2ConnMock) CreateTags(req *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error) {


### PR DESCRIPTION
When launching ec2 source instances, we have code which waits for the instance to become ready, but previously this codepath was not being applied to spot instances.

This change factors that code out into a common function, and then calls that common function in both the 'regular' and 'spot' instance launches.

This fixes issues where packer tries to connect to a spot instance before it is running and ready, which means it won't have a public ip address ready yet, and so packer times out on SSH access.

fixes #40