### PR TITLE
Instance SSH access: use all attempts to get public IP

### DIFF
--- a/builder/common/ssh.go
+++ b/builder/common/ssh.go
@@ -60,7 +60,9 @@ func SSHHost(e ec2Describer, sshInterface string, host string) func(multistep.St
 			} else if i.VpcId != nil && *i.VpcId != "" {
 				if i.PublicIpAddress != nil && *i.PublicIpAddress != "" {
 					host = *i.PublicIpAddress
-				} else if i.PrivateIpAddress != nil && *i.PrivateIpAddress != "" {
+				} else if i.PrivateIpAddress != nil && *i.PrivateIpAddress != "" && j == tries {
+					// if this is the final try, fallback to private ip address, otherwise continue
+					// trying to get a public ip address.
 					host = *i.PrivateIpAddress
 				}
 			} else if i.PublicDnsName != nil && *i.PublicDnsName != "" {


### PR DESCRIPTION
Previously the ssh access IP would fallback to the private ip address on the first "try" if a public IP is not available yet.

This changes the logic to only fallback to private IP address if we are on the final attempt at finding an IP address.

Precedence of always preferring public IP is left unchanged.

related to #40 and #308

