### PR TITLE
Handle SSM session disconnection w/ AWS get connection status.

### DIFF
--- a/builder/common/ssm/session.go
+++ b/builder/common/ssm/session.go
@@ -89,52 +89,31 @@ func (s Session) getCommand(ctx context.Context) ([]string, string, error) {
 // context. If you do not wish to terminate the session manually: calling
 // StopSession on a instance of this driver will terminate the active session
 // created from calling StartSession.
-func (s Session) Start(ctx context.Context, ui packersdk.Ui) error {
-	log.Printf("ssm: Starting PortForwarding session to instance %s", s.InstanceID)
-	args, sessionID, err := s.getCommand(ctx)
-	if sessionID != "" {
-		defer func() {
-			_, err := s.SvcClient.TerminateSession(&ssm.TerminateSessionInput{SessionId: aws.String(sessionID)})
-			if err != nil {
-				ui.Error(fmt.Sprintf("Error terminating SSM Session %q. Please terminate the session manually: %s", sessionID, err))
-			}
-		}()
-	}
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.CommandContext(ctx, "session-manager-plugin", args...)
-
-	ui.Message(fmt.Sprintf("Starting portForwarding session %q.", sessionID))
-	err = localexec.RunAndStream(cmd, ui, nil)
-	if err != nil {
-		ui.Error(err.Error())
-	}
-	return nil
-}
-
-// Behaves like Start but will reconnect if the session is disconnected
 // To stop the session you must cancel the context.
-// The channel is used to notify when a new session is started
-func (s Session) StartWithReconnect(ctx context.Context, ui packersdk.Ui, sessionChan chan struct{}) error {
+func (s Session) Start(ctx context.Context, ui packersdk.Ui, sessionChan chan struct{}) error {
 	for ctx.Err() == nil {
-		ssmAvailable, err := s.SvcClient.GetConnectionStatus(&ssm.GetConnectionStatusInput{
-			Target: &s.InstanceID,
-		})
+		log.Printf("ssm: Starting PortForwarding session to instance %s", s.InstanceID)
+		args, sessionID, err := s.getCommand(ctx)
+		if sessionID != "" {
+			defer func() {
+				_, err := s.SvcClient.TerminateSession(&ssm.TerminateSessionInput{SessionId: aws.String(sessionID)})
+				if err != nil {
+					ui.Error(fmt.Sprintf("Error terminating SSM Session %q. Please terminate the session manually: %s", sessionID, err))
+				}
+			}()
+		}
 		if err != nil {
-			log.Printf("error getting ssm connection status: %s", err)
+			return err
 		}
-		switch *ssmAvailable.Status {
-		case "connected":
-			ui.Say(fmt.Sprintf("ssm: start PortForwarding session to instance %s", s.InstanceID))
-			sessionChan <- struct{}{}
-			err = s.Start(ctx, ui)
-			if err != nil {
-				ui.Error(fmt.Sprintf("ssm error: %s", err))
-			}
+
+		sessionChan <- struct{}{}
+		cmd := exec.CommandContext(ctx, "session-manager-plugin", args...)
+
+		ui.Message(fmt.Sprintf("Starting portForwarding session %q.", sessionID))
+		err = localexec.RunAndStream(cmd, ui, nil)
+		if err != nil {
+			ui.Error(err.Error())
 		}
-		time.Sleep(30 * time.Second)
 	}
 	ui.Say("ssm: PortForwarding session is finished")
 	close(sessionChan)

--- a/builder/common/ssm/session.go
+++ b/builder/common/ssm/session.go
@@ -115,7 +115,7 @@ func (s Session) Start(ctx context.Context, ui packersdk.Ui) error {
 }
 
 // Behaves like Start but will reconnect if the session is disconnected
-// To stop the session you must cancell the context.
+// To stop the session you must cancel the context.
 // The channel is used to notify when a new session is started
 func (s Session) StartWithReconnect(ctx context.Context, ui packersdk.Ui, sessionChan chan struct{}) error {
 	for ctx.Err() == nil {

--- a/builder/common/step_create_ssm_tunnel.go
+++ b/builder/common/step_create_ssm_tunnel.go
@@ -90,10 +90,10 @@ func (s *StepCreateSSMTunnel) CreatePersistentSSMSession(ctx context.Context, ui
 
 	go session.Start(ctx, ui, sessionChan)
 
-	if len(s.SSHConfig.SSHPrivateKey) != 0 && s.SSHConfig.SSHKeyPairName == "" {
-		// SSH public key sent expires every minute.
-		// Send it upon each reconnect to ensure it is always valid.
-		for range sessionChan {
+	// SSH public key sent expires every minute.
+	// Send it upon each reconnect to ensure it is always valid.
+	for range sessionChan {
+		if len(s.SSHConfig.SSHPrivateKey) != 0 && s.SSHConfig.SSHKeyPairName == "" {
 			ui.Say("Uploading SSH public key to instance")
 			err := s.sendUserSSHPublicKey(instance, s.SSHConfig.SSHPrivateKey)
 			if err != nil {

--- a/builder/common/step_create_ssm_tunnel.go
+++ b/builder/common/step_create_ssm_tunnel.go
@@ -93,13 +93,11 @@ func (s *StepCreateSSMTunnel) CreatePersistentSSMSession(ctx context.Context, ui
 	if len(s.SSHConfig.SSHPrivateKey) != 0 && s.SSHConfig.SSHKeyPairName == "" {
 		// SSH public key sent expires every minute.
 		// Send it upon each reconnect to ensure it is always valid.
-		if len(s.SSHConfig.SSHPrivateKey) != 0 && s.SSHConfig.SSHKeyPairName == "" {
-			for range sessionChan {
-				ui.Say("Uploading SSH public key to instance")
-				err := s.sendUserSSHPublicKey(instance, s.SSHConfig.SSHPrivateKey)
-				if err != nil {
-					ui.Error(err.Error())
-				}
+		for range sessionChan {
+			ui.Say("Uploading SSH public key to instance")
+			err := s.sendUserSSHPublicKey(instance, s.SSHConfig.SSHPrivateKey)
+			if err != nil {
+				ui.Error(err.Error())
 			}
 		}
 	}


### PR DESCRIPTION
With the current implementation was failing in case of a restart in execution commands

## Solution

With the current implementation was failing in case of a restart in execution commands, for example:
```hcl
build {
  sources = ["source.amazon-ebs.test"]
  provisioner "shell" {
    expect_disconnect = true
    script            = "./reboot.sh"
  }
  provisioner "shell" {
    inline = ["echo 'Hello World!'", "echo >>/home/ec2-user/test-inline.txt"]
  }
}
```
Would not continue after the first script is ran.

To fix this I have changed the code to monitor the instance connection status to SSM service, and in case the session is disconnected it will re-create another session to SMS. This session will be kept open(in case of future crashes) until the packer actually stops the instance.

A few important details:

**How do we identify when to create new session?**

After we run the command to create a [session with port forwarding](https://github.dev/hashicorp/packer-plugin-amazon/blob/3a8a7dd29b0a2ed5bee6636d15c7bb2181098bab/builder/common/ssm/session.go#L111) when the instance restarts then this command will output the error message:
```
amazon-ebs.test: Connection to destination port failed, check SSM Agent logs.
```

After ~1.5 minutes the session manager plugin exits with the message:

```
document process failed unexpectedly: document worker timed out , check [ssm-document-worker]/[ssm-session-worker] log for crash reason
```

After this message we start another SSM session, and the Provision step reconnects to that session, since session is on the same port the reconnection succeeds.

## New Behavior

SSM session will reconnect in case the connection drops until the builder stops the instance(The actual build finishes). In order for the SSM session without a keypair, the ssh public key has to be sent periodically.

## Test

This is the build spec I used for the test:
```
build {
  sources = ["source.amazon-ebs.test"]
  provisioner "shell" {
    expect_disconnect = true
    script            = "./reboot.sh"
  }
  provisioner "shell" {
    inline = ["echo 'Hello World!'", "echo >>/home/ec2-user/test-inline.txt"]
  }
}
```

and reboot script is:
```
echo "Hello I'm rebooting you"

sudo reboot
```

