### PR TITLE
Skip uploading ssh pub key when AWS key pair is used

### DIFF
--- a/builder/common/step_create_ssm_tunnel.go
+++ b/builder/common/step_create_ssm_tunnel.go
@@ -87,7 +87,7 @@ func (s *StepCreateSSMTunnel) Run(ctx context.Context, state multistep.StateBag)
 		}
 	}()
 
-	if len(s.SSHConfig.SSHPrivateKey) != 0 {
+	if len(s.SSHConfig.SSHPrivateKey) != 0 && s.SSHConfig.SSHKeyPairName == "" {
 		ui.Say("Uploading SSH public key to instance")
 		err := s.sendUserSSHPublicKey(instance, s.SSHConfig.SSHPrivateKey)
 		if err != nil {

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -540,6 +540,15 @@ func TestAccBuilder_EbsSessionManagerInterface(t *testing.T) {
 					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
 				}
 			}
+
+			logs, err := os.ReadFile(logfile)
+			if err != nil {
+				return fmt.Errorf("couldn't read logs from logfile %s: %s", logfile, err)
+			}
+			if strings.Contains(string(logs), "Uploading SSH public key") {
+				return fmt.Errorf("SSH key was uploaded, but shouldn't have been")
+			}
+
 			return nil
 		},
 	}


### PR DESCRIPTION
Skip uploading SSH public key to the instance in case the AWS key pair is used.

In case key pair is generated and it's not specified by the user uploading the key is not necessary.

Since this issue can be identified with the roles running packer itself, I'm unsure if I can reflect this change in tests. Any help is appreciated. I tested it on my local machine with two configs:

- With SSM and no privateKeyFile: Does not upload the pub key
- With SSM and with privateKeyFile: Uploads the pub key

Closes #313

