### PR TITLE
acceptance: use pure Go for generating temp keys

### DIFF
--- a/builder/ebs/acceptance/utils.go
+++ b/builder/ebs/acceptance/utils.go
@@ -1,21 +1,32 @@
 package amazon_acc
 
 import (
-	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
-	"os/exec"
 )
 
 func GenerateSSHPrivateKeyFile() (string, error) {
-	outFile := fmt.Sprintf("%s/temp_key.ed25519", os.TempDir())
-	sshGenCmd := exec.Command("ssh-keygen", "-t", "ed25519", "-b", "256", "-f", outFile)
-	sshGenCmd.Stdin = bytes.NewBuffer([]byte("\n\n"))
+	outFile := fmt.Sprintf("%s/temp_key", os.TempDir())
 
-	_, err := sshGenCmd.CombinedOutput()
+	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
-		os.Remove(outFile)
-		return "", err
+		return "", fmt.Errorf("failed to generate SSH key: %s", err)
+	}
+
+	x509key := x509.MarshalPKCS1PrivateKey(priv)
+
+	pemKey := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509key,
+	})
+
+	err = os.WriteFile(outFile, pemKey, 0600)
+	if err != nil {
+		return "", fmt.Errorf("failed to write private key to %q: %s", outFile, err)
 	}
 
 	return outFile, nil


### PR DESCRIPTION
Some acceptance tests require generating a temporary SSH key pair for ensuring they are sent to AWS and that we can connect through SSH to an instance with a user-provided key.

This was implemented through `ssh-keygen', part of the openssh suite of tools, but because the behaviour may change between environments, we opted to rewrite the keygen steps in pure go, by relying on the functions exposed by the `crypto' standard library.