### PR TITLE
Harden EBS ssh key tests

### DIFF
--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -834,6 +834,15 @@ func TestAccBuilder_EnableUnlimitedCredits_withSpotInstances(t *testing.T) {
 			if buildCommand.ProcessState.ExitCode() != 0 {
 				return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
 			}
+
+			logs, err := os.ReadFile(logfile)
+			if err != nil {
+				return fmt.Errorf("couldn't read logs from logfile %s: %s", logfile, err)
+			}
+			if !strings.Contains(string(logs), "Uploading SSH public key") {
+				return fmt.Errorf("SSH key was not uploaded, but should have been")
+			}
+
 			return nil
 		},
 	}

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -780,12 +780,6 @@ func TestAccBuilder_EbsKeyPair_rsaSHA2OnlyServer(t *testing.T) {
 }
 
 func TestAccBuilder_PrivateKeyFile(t *testing.T) {
-	if os.Getenv(acctest.TestEnvVar) == "" {
-		t.Skipf("Acceptance tests skipped unless env '%s' set",
-			acctest.TestEnvVar)
-		return
-	}
-
 	ami := amazon_acc.AMIHelper{
 		Region: "us-east-1",
 		Name:   fmt.Sprintf("packer-pkey-file-acc-test-%d", time.Now().Unix()),


### PR DESCRIPTION
The acceptance test that would generate an SSH key prior to running it was failing on Windows machines in CI as it made the process timeout.

While this is not clear why that happens, we fixed the issue earlier by adding this extra check prior to running the test, so it is not run when running normal tests in CI.

Because we now generate this SSH key directly from Go code, and not by relying on ssh-keygen, we can remove this as we don't risk encountering this problem anymore.

In addition, the EBS test in which we push the public key corresponding to the private key we add in the configuration on an SSM-backed connection would not check that the SSH public key upload message was in the output, potentially leading to some inconsistencies in the future.

To avoid this from happening at some point, we add an extra check that the message was indeed in the output.
