### PR TITLE
iam: attach tags to instance role and profile

### DIFF
--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -278,7 +278,7 @@ type RunConfig struct {
 	//
 	// `security_group_ids` take precedence over this.
 	SecurityGroupFilter SecurityGroupFilterOptions `mapstructure:"security_group_filter" required:"false"`
-	// Key/value pair tags to apply to the generated key-pair, security group, snapshot and instance
+	// Key/value pair tags to apply to the generated key-pair, security group, iam profile and role, snapshot and instance
 	// that is *launched* to create the EBS volumes. The resulting AMI will also inherit these tags.
 	// This is a [template
 	// engine](/packer/docs/templates/legacy_json_templates/engine), see [Build template

--- a/builder/common/tags.go
+++ b/builder/common/tags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
@@ -41,6 +42,28 @@ func (t TagMap) EC2Tags(ictx interpolate.Context, region string, state multistep
 		})
 	}
 	return ec2Tags, nil
+}
+
+func (t TagMap) IamTags(ictx interpolate.Context, region string, state multistep.StateBag) ([]*iam.Tag, error) {
+	var iamTags []*iam.Tag
+	generatedData := packerbuilderdata.GeneratedData{State: state}
+	ictx.Data = extractBuildInfo(region, state, &generatedData)
+
+	for key, value := range t {
+		interpolatedKey, err := interpolate.Render(key, &ictx)
+		if err != nil {
+			return nil, fmt.Errorf("Error processing tag: %s:%s - %s", key, value, err)
+		}
+		interpolatedValue, err := interpolate.Render(value, &ictx)
+		if err != nil {
+			return nil, fmt.Errorf("Error processing tag: %s:%s - %s", key, value, err)
+		}
+		iamTags = append(iamTags, &iam.Tag{
+			Key:   aws.String(interpolatedKey),
+			Value: aws.String(interpolatedValue),
+		})
+	}
+	return iamTags, nil
 }
 
 func (t EC2Tags) TagSpecifications(resourceType ...string) []*ec2.TagSpecification {

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -321,6 +321,8 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			IamInstanceProfile:                        b.config.IamInstanceProfile,
 			SkipProfileValidation:                     b.config.SkipProfileValidation,
 			TemporaryIamInstanceProfilePolicyDocument: b.config.TemporaryIamInstanceProfilePolicyDocument,
+			Tags: b.config.RunTags,
+			Ctx:  b.config.ctx,
 		},
 		&awscommon.StepCleanupVolumes{
 			LaunchMappings: b.config.LaunchMappings,


### PR DESCRIPTION
RunTags value is used to set tags for resources created by packer except for Iam role and profile. This PR adds the tags when creating these resources.
Resolves #322

This will also address part of #286
