### PR TITLE
Add run_tags to ec2 instance network interfaces

### DIFF
--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -278,7 +278,7 @@ type RunConfig struct {
 	//
 	// `security_group_ids` take precedence over this.
 	SecurityGroupFilter SecurityGroupFilterOptions `mapstructure:"security_group_filter" required:"false"`
-	// Key/value pair tags to apply to the generated key-pair, security group, snapshot and instance
+	// Key/value pair tags to apply to the generated key-pair, security group, iam profile and role, snapshot, network interfaces and instance
 	// that is *launched* to create the EBS volumes. The resulting AMI will also inherit these tags.
 	// This is a [template
 	// engine](/packer/docs/templates/legacy_json_templates/engine), see [Build template

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -386,13 +386,13 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 
 		if len(ec2Tags) > 0 {
 			for _, networkInterface := range instance.NetworkInterfaces {
+				log.Printf("Tagging network interface %s", *networkInterface.NetworkInterfaceId)
 				_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
 					Tags:      ec2Tags,
 					Resources: []*string{networkInterface.NetworkInterfaceId},
 				})
-				log.Printf("Tagging network interface %s", *networkInterface.NetworkInterfaceId)
 				if err != nil {
-					ui.Say(fmt.Sprintf("Error tagging source instance's network interface %q: %s", *networkInterface.NetworkInterfaceId, err))
+					ui.Error(fmt.Sprintf("Error tagging source instance's network interface %q: %s", *networkInterface.NetworkInterfaceId, err))
 				}
 			}
 		}

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -392,7 +392,7 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 				})
 				log.Printf("Tagging network interface %s", *networkInterface.NetworkInterfaceId)
 				if err != nil {
-					ui.Say(fmt.Sprintf("Error tagging source instance's network interface: %s, skip tagging network interfaces", err))
+					ui.Say(fmt.Sprintf("Error tagging source instance's network interface %q: %s", *networkInterface.NetworkInterfaceId, err))
 				}
 			}
 		}

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -182,6 +182,13 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 		}
 
 		tagSpecs = append(tagSpecs, runTags)
+
+		networkInterfaceTags := &ec2.TagSpecification{
+			ResourceType: aws.String("network-interface"),
+			Tags:         ec2Tags,
+		}
+
+		tagSpecs = append(tagSpecs, networkInterfaceTags)
 	}
 
 	if len(volTags) > 0 {
@@ -377,6 +384,18 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 			return multistep.ActionHalt
 		}
 
+		if len(ec2Tags) > 0 {
+			for _, networkInterface := range instance.NetworkInterfaces {
+				_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{
+					Tags:      ec2Tags,
+					Resources: []*string{networkInterface.NetworkInterfaceId},
+				})
+				log.Printf("Tagging network interface %s", *networkInterface.NetworkInterfaceId)
+				if err != nil {
+					ui.Say(fmt.Sprintf("Error tagging source instance's network interface: %s, skip tagging network interfaces", err))
+				}
+			}
+		}
 		// Now tag volumes
 
 		volumeIds := make([]*string, 0)

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -316,6 +316,14 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 				Tags:         ec2Tags,
 			},
 		)
+
+		launchTemplate.LaunchTemplateData.TagSpecifications = append(
+			launchTemplate.LaunchTemplateData.TagSpecifications,
+			&ec2.LaunchTemplateTagSpecificationRequest{
+				ResourceType: aws.String("network-interface"),
+				Tags:         ec2Tags,
+			},
+		)
 	}
 
 	if len(volumeTags) > 0 {


### PR DESCRIPTION
This PR adds run_tags to ec2 instance network interfaces.

From the [RunInstanceInput](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#RunInstancesInput) we can see that the NetworkInterface tags are also applied from the TagSpecification field.

To test the code block in the IsRestricted, I manually turned it on and built an AMI.

Closes #286 

