### PR TITLE
Copy tags on copy ami

### DIFF
--- a/builder/common/step_ami_region_copy.go
+++ b/builder/common/step_ami_region_copy.go
@@ -202,12 +202,14 @@ func (s *StepAMIRegionCopy) amiRegionCopy(ctx context.Context, state multistep.S
 	if err != nil {
 		return "", snapshotIds, err
 	}
+	t := true
 	resp, err := regionconn.CopyImage(&ec2.CopyImageInput{
 		SourceRegion:  &source,
 		SourceImageId: &imageId,
 		Name:          &name,
 		Encrypted:     encrypt,
 		KmsKeyId:      aws.String(keyId),
+		CopyImageTags: &t,
 	})
 
 	if err != nil {

--- a/builder/common/step_ami_region_copy_test.go
+++ b/builder/common/step_ami_region_copy_test.go
@@ -32,6 +32,9 @@ type mockEC2Conn struct {
 }
 
 func (m *mockEC2Conn) CopyImage(copyInput *ec2.CopyImageInput) (*ec2.CopyImageOutput, error) {
+	if !*copyInput.CopyImageTags {
+		return nil, fmt.Errorf("CopyImageTags should always be true, but was %t", *copyInput.CopyImageTags)
+	}
 	m.lock.Lock()
 	m.copyImageCount++
 	m.lock.Unlock()


### PR DESCRIPTION
As pointed out in #295, the tags specified as `run_tags` in a template are applied to the resulting base AMI, but are not copied to the AMIs that are copied from it to other regions.

This does not apply to tags specified through the `tags` attribute since they are manually copied through an extra step, after the AMIs are created and copied.

To fix the first use case, Amazon added support for copying the tags when an AMI is copied to another region, so we leverage that in this PR.

Closes #295 

