### PR TITLE
Clarify reason for invalid throughput error message

### DIFF
--- a/builder/common/block_device.go
+++ b/builder/common/block_device.go
@@ -212,8 +212,8 @@ func (b *BlockDevice) Prepare(ctx *interpolate.Context) error {
 				minIopsGp3, maxIopsGp3, b.DeviceName)
 		}
 	} else if b.Throughput != nil {
-		return fmt.Errorf("Throughput is not available for device %s",
-			b.DeviceName)
+		return fmt.Errorf("Throughput is only valid for gp3 volumes, %q is of type %s",
+			b.DeviceName, b.VolumeType)
 	}
 
 	_, err := interpolate.RenderInterface(&b, ctx)


### PR DESCRIPTION
Clarifying the reason for error message saying throughput is unavailable.

While building an Ubuntu AMI using [kubernetes-sigs/image-builder](https://github.com/kubernetes-sigs/image-builder), which uses Packer (and packer-plugin-amazon) under the hood, I got the following error:
```bash
Error: Failed to prepare build: “ubuntu-20.04”

1 error(s) occurred:

* Throughput is not available for device /dev/sda1
```

I had set my volume type to `gp2` and did not set throughput, but what I didn't know at the time was that image-builder has a default throughput value of `125` set [here](https://github.com/kubernetes-sigs/image-builder/blob/master/images/capi/packer/ami/packer.json#L204), which was causing the volume type/throughput incompatibility. I am aware now that the docs mention the throughput is valid only for gp3 types, but tt would definitely have saved me some debugging if the build output had reported the same in the error message.