### PR TITLE
docs: add other tagged resources to run_tags description

### DIFF
--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -180,7 +180,7 @@
   
   `security_group_ids` take precedence over this.
 
-- `run_tags` (map[string]string) - Key/value pair tags to apply to the generated key-pair, security group, snapshot and instance
+- `run_tags` (map[string]string) - Key/value pair tags to apply to the generated key-pair, security group, iam profile and role, snapshot, network interfaces and instance
   that is *launched* to create the EBS volumes. The resulting AMI will also inherit these tags.
   This is a [template
   engine](/packer/docs/templates/legacy_json_templates/engine), see [Build template


### PR DESCRIPTION
I realized after updating the run_config documents in #326 & #323 I forgot to run the packer-sdc. I just learned what does it do.