### PR TITLE
Tpm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ packer-plugin-amazon
 .docs
 .DS_Store
 *.sw*
+.idea/

--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -207,6 +207,10 @@ type Config struct {
 	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
 	// for more information. Defaults to legacy.
 	IMDSSupport string `mapstructure:"imds_support" required:"false"`
+	// NitroTPM Support. Valid options are `v2.0`. See the documentation on
+	// [NitroTPM Support](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enable-nitrotpm-support-on-ami.html) for
+	// more information. Only enabled if a valid option is provided, otherwise ignored.
+	TpmSupport string `mapstructure:"tpm_support" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -382,6 +386,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid imds_support values are %q or the empty string`, ec2.ImdsSupportValuesV20))
 	}
 
+	if b.config.TpmSupport != "" && b.config.TpmSupport != ec2.TpmSupportValuesV20 {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid tpm_support values are %q or the empty string`, ec2.TpmSupportValuesV20))
+	}
+
 	if b.config.BootMode != "" {
 		valid := false
 		for _, validBootMode := range []string{"legacy-bios", "uefi"} {
@@ -525,6 +533,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			BootMode:                 b.config.BootMode,
 			UefiData:                 b.config.UefiData,
 			IMDSSupport:              b.config.IMDSSupport,
+			TpmSupport:				  b.config.TpmSupport,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,

--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -533,7 +533,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			BootMode:                 b.config.BootMode,
 			UefiData:                 b.config.UefiData,
 			IMDSSupport:              b.config.IMDSSupport,
-			TpmSupport:				  b.config.TpmSupport,
+			TpmSupport:               b.config.TpmSupport,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,

--- a/builder/chroot/builder.hcl2spec.go
+++ b/builder/chroot/builder.hcl2spec.go
@@ -85,6 +85,7 @@ type FlatConfig struct {
 	BootMode                *string                           `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
 	UefiData                *string                           `mapstructure:"uefi_data" required:"false" cty:"uefi_data" hcl:"uefi_data"`
 	IMDSSupport             *string                           `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
+	TPMSupport             *string                           `mapstructure:"tpm_support" required:"false" cty:"tpm_support" hcl:"tpm_support"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -172,6 +173,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_mode":                     &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
 		"uefi_data":                     &hcldec.AttrSpec{Name: "uefi_data", Type: cty.String, Required: false},
 		"imds_support":                  &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"tpm_support":                   &hcldec.AttrSpec{Name: "tpm_support", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/chroot/builder.hcl2spec.go
+++ b/builder/chroot/builder.hcl2spec.go
@@ -85,7 +85,7 @@ type FlatConfig struct {
 	BootMode                *string                           `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
 	UefiData                *string                           `mapstructure:"uefi_data" required:"false" cty:"uefi_data" hcl:"uefi_data"`
 	IMDSSupport             *string                           `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
-	TPMSupport             *string                           `mapstructure:"tpm_support" required:"false" cty:"tpm_support" hcl:"tpm_support"`
+	TPMSupport              *string                           `mapstructure:"tpm_support" required:"false" cty:"tpm_support" hcl:"tpm_support"`
 }
 
 // FlatMapstructure returns a new FlatConfig.

--- a/builder/chroot/builder_test.go
+++ b/builder/chroot/builder_test.go
@@ -356,3 +356,53 @@ func TestBuilderPrepare_IMDSSupportValue(t *testing.T) {
 		})
 	}
 }
+
+func TestBuilderPrepare_TpmSupportValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		optValue    string
+		expectError bool
+	}{
+		{
+			name:        "OK - no value set",
+			optValue:    "",
+			expectError: false,
+		},
+		{
+			name:        "OK - v2.0",
+			optValue:    "v2.0",
+			expectError: false,
+		},
+		{
+			name:        "Error - bad value set",
+			optValue:    "v3.0",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := testConfig()
+			config["ami_name"] = "name"
+			config["root_device_name"] = "/dev/sda"
+			config["ami_block_device_mappings"] = []interface{}{map[string]string{}}
+			config["root_volume_size"] = 15
+
+			config["tpm_support"] = tt.optValue
+
+			b := &Builder{}
+
+			_, _, err := b.Prepare(config)
+			if err != nil && !tt.expectError {
+				t.Fatalf("got unexpected error: %s", err)
+			}
+			if err == nil && tt.expectError {
+				t.Fatalf("expected an error, got a success instead")
+			}
+
+			if err != nil {
+				t.Logf("OK: b.Prepare produced expected error: %s", err)
+			}
+		})
+	}
+}

--- a/builder/chroot/step_attach_volume.go
+++ b/builder/chroot/step_attach_volume.go
@@ -16,8 +16,9 @@ import (
 // available device location.
 //
 // Produces:
-//   device string - The location where the volume was attached.
-//   attach_cleanup CleanupFunc
+//
+//	device string - The location where the volume was attached.
+//	attach_cleanup CleanupFunc
 type StepAttachVolume struct {
 	PollingConfig *awscommon.AWSPollingConfig
 	attached      bool

--- a/builder/chroot/step_create_volume.go
+++ b/builder/chroot/step_create_volume.go
@@ -19,7 +19,8 @@ import (
 // device of the AMI.
 //
 // Produces:
-//   volume_id string - The ID of the created volume
+//
+//	volume_id string - The ID of the created volume
 type StepCreateVolume struct {
 	PollingConfig         *awscommon.AWSPollingConfig
 	volumeId              string

--- a/builder/chroot/step_flock.go
+++ b/builder/chroot/step_flock.go
@@ -14,7 +14,8 @@ import (
 // StepFlock provisions the instance within a chroot.
 //
 // Produces:
-//   flock_cleanup Cleanup - To perform early cleanup
+//
+//	flock_cleanup Cleanup - To perform early cleanup
 type StepFlock struct {
 	fh *os.File
 }

--- a/builder/chroot/step_mount_device.go
+++ b/builder/chroot/step_mount_device.go
@@ -24,8 +24,9 @@ type mountPathData struct {
 // StepMountDevice mounts the attached device.
 //
 // Produces:
-//   mount_path string - The location where the volume was mounted.
-//   mount_device_cleanup CleanupFunc - To perform early cleanup
+//
+//	mount_path string - The location where the volume was mounted.
+//	mount_device_cleanup CleanupFunc - To perform early cleanup
 type StepMountDevice struct {
 	MountOptions   []string
 	MountPartition string

--- a/builder/chroot/step_register_ami.go
+++ b/builder/chroot/step_register_ami.go
@@ -23,6 +23,7 @@ type StepRegisterAMI struct {
 	BootMode                 string
 	UefiData                 string
 	IMDSSupport              string
+	TpmSupport               string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -78,6 +79,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	if s.IMDSSupport != "" {
 		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)
+	}
+	if s.TpmSupport != "" {
+		registerOpts.TpmSupport = aws.String(s.TpmSupport)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/builder/chroot/step_snapshot.go
+++ b/builder/chroot/step_snapshot.go
@@ -14,7 +14,8 @@ import (
 // StepSnapshot creates a snapshot of the created volume.
 //
 // Produces:
-//   snapshot_id string - ID of the created snapshot
+//
+//	snapshot_id string - ID of the created snapshot
 type StepSnapshot struct {
 	PollingConfig *awscommon.AWSPollingConfig
 	snapshotId    string

--- a/builder/common/access_config.go
+++ b/builder/common/access_config.go
@@ -32,26 +32,30 @@ import (
 // HCL config example:
 //
 // ```HCL
-// source "amazon-ebs" "example" {
-// 	assume_role {
-// 		role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-// 		session_name = "SESSION_NAME"
-// 		external_id  = "EXTERNAL_ID"
-// 	}
-// }
+//
+//	source "amazon-ebs" "example" {
+//		assume_role {
+//			role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+//			session_name = "SESSION_NAME"
+//			external_id  = "EXTERNAL_ID"
+//		}
+//	}
+//
 // ```
 //
 // JSON config example:
 //
 // ```json
-// builder{
-// 	"type": "amazon-ebs",
-// 	"assume_role": {
-// 		"role_arn"    :  "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
-// 		"session_name":  "SESSION_NAME",
-// 		"external_id" :  "EXTERNAL_ID"
-// 	}
-// }
+//
+//	builder{
+//		"type": "amazon-ebs",
+//		"assume_role": {
+//			"role_arn"    :  "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
+//			"session_name":  "SESSION_NAME",
+//			"external_id" :  "EXTERNAL_ID"
+//		}
+//	}
+//
 // ```
 type AssumeRoleConfig struct {
 	// Amazon Resource Name (ARN) of the IAM Role to assume.

--- a/builder/common/awserrors/utils.go
+++ b/builder/common/awserrors/utils.go
@@ -7,9 +7,9 @@ import (
 )
 
 // Returns true if the err matches all these conditions:
-//  * err is of type awserr.Error
-//  * Error.Code() matches code
-//  * Error.Message() contains message
+//   - err is of type awserr.Error
+//   - Error.Code() matches code
+//   - Error.Message() contains message
 func Matches(err error, code string, message string) bool {
 	if err, ok := err.(awserr.Error); ok {
 		return err.Code() == code && strings.Contains(err.Message(), message)

--- a/builder/common/block_device.go
+++ b/builder/common/block_device.go
@@ -33,21 +33,25 @@ const (
 // HCL2 example:
 //
 // ```hcl
-// launch_block_device_mappings {
-//     device_name = "/dev/sda1"
-//     encrypted = true
-//     kms_key_id = "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
-// }
+//
+//	launch_block_device_mappings {
+//	    device_name = "/dev/sda1"
+//	    encrypted = true
+//	    kms_key_id = "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
+//	}
+//
 // ```
 //
 // JSON example:
 // ```json
 // "launch_block_device_mappings": [
-//   {
-//      "device_name": "/dev/sda1",
-//      "encrypted": true,
-//      "kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
-//   }
+//
+//	{
+//	   "device_name": "/dev/sda1",
+//	   "encrypted": true,
+//	   "kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
+//	}
+//
 // ]
 // ```
 //
@@ -56,7 +60,6 @@ const (
 //
 // Documentation for Block Devices Mappings can be found here:
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
-//
 type BlockDevice struct {
 	// Indicates whether the EBS volume is deleted on instance termination.
 	// Default false. NOTE: If this value is not explicitly set to true and

--- a/builder/common/step_network_info.go
+++ b/builder/common/step_network_info.go
@@ -16,9 +16,10 @@ import (
 // VPC's and Subnets that is used throughout the AMI creation process.
 //
 // Produces (adding them to the state bag):
-//   vpc_id string - the VPC ID
-//   subnet_id string - the Subnet ID
-//   availability_zone string - the AZ name
+//
+//	vpc_id string - the VPC ID
+//	subnet_id string - the Subnet ID
+//	availability_zone string - the AZ name
 type StepNetworkInfo struct {
 	VpcId               string
 	VpcFilter           VpcFilterOptions

--- a/builder/common/step_pre_validate.go
+++ b/builder/common/step_pre_validate.go
@@ -17,7 +17,6 @@ import (
 
 // StepPreValidate provides an opportunity to pre-validate any configuration for
 // the build before actually doing any time consuming work
-//
 type StepPreValidate struct {
 	DestAmiName        string
 	ForceDeregister    bool

--- a/builder/common/step_pre_validate_test.go
+++ b/builder/common/step_pre_validate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-//DescribeVpcs mocks an ec2.DescribeVpcsOutput for a given input
+// DescribeVpcs mocks an ec2.DescribeVpcsOutput for a given input
 func (m *mockEC2Conn) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
 
 	if input == nil || aws.StringValue(input.VpcIds[0]) == "" {

--- a/builder/common/step_source_ami_info.go
+++ b/builder/common/step_source_ami_info.go
@@ -16,7 +16,8 @@ import (
 // that is used throughout the AMI creation process.
 //
 // Produces:
-//   source_image *ec2.Image - the source AMI info
+//
+//	source_image *ec2.Image - the source AMI info
 type StepSourceAMIInfo struct {
 	SourceAmi                string
 	EnableAMISriovNetSupport bool

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -83,6 +83,10 @@ type Config struct {
 	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
 	// for more information. Defaults to legacy.
 	IMDSSupport string `mapstructure:"imds_support" required:"false"`
+	// NitroTPM Support. Valid options are `v2.0`. See the documentation on
+	// [NitroTPM Support](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enable-nitrotpm-support-on-ami.html) for
+	// more information. Only enabled if a valid option is provided, otherwise ignored.
+	TpmSupport string `mapstructure:"tpm_support" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -187,6 +191,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if b.config.IMDSSupport != "" && b.config.IMDSSupport != ec2.ImdsSupportValuesV20 {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid imds_support values are %q or the empty string`, ec2.ImdsSupportValuesV20))
+	}
+
+	if b.config.TpmSupport != "" && b.config.TpmSupport != ec2.TpmSupportValuesV20 {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid tpm_support values are %q or the empty string`, ec2.TpmSupportValuesV20))
 	}
 
 	if b.config.BootMode != "" {
@@ -448,6 +456,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			BootMode:                 b.config.BootMode,
 			UefiData:                 b.config.UefiData,
 			IMDSSupport:              b.config.IMDSSupport,
+			TpmSupport:               b.config.TpmSupport,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:       &b.config.AccessConfig,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -209,6 +209,7 @@ type FlatConfig struct {
 	BootMode                                  *string                                `mapstructure:"boot_mode" required:"false" cty:"boot_mode" hcl:"boot_mode"`
 	UefiData                                  *string                                `mapstructure:"uefi_data" required:"false" cty:"uefi_data" hcl:"uefi_data"`
 	IMDSSupport                               *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
+	TpmSupport                                *string                                `mapstructure:"tpm_support" required:"false" cty:"tpm_support" hcl:"tpm_support"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -375,6 +376,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"boot_mode":                    &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
 		"uefi_data":                    &hcldec.AttrSpec{Name: "uefi_data", Type: cty.String, Required: false},
 		"imds_support":                 &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"tpm_support":                  &hcldec.AttrSpec{Name: "tpm_support", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/ebssurrogate/step_register_ami.go
+++ b/builder/ebssurrogate/step_register_ami.go
@@ -28,6 +28,7 @@ type StepRegisterAMI struct {
 	BootMode                 string
 	UefiData                 string
 	IMDSSupport              string
+	TpmSupport               string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -83,6 +84,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	if s.IMDSSupport != "" {
 		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)
+	}
+	if s.TpmSupport != "" {
+		registerOpts.TpmSupport = aws.String(s.TpmSupport)
 	}
 	registerResp, err := ec2conn.RegisterImage(registerOpts)
 	if err != nil {

--- a/builder/ebssurrogate/step_snapshot_volumes.go
+++ b/builder/ebssurrogate/step_snapshot_volumes.go
@@ -18,7 +18,8 @@ import (
 // StepSnapshotVolumes creates snapshots of the created volumes.
 //
 // Produces:
-//   snapshot_ids map[string]string - IDs of the created snapshots
+//
+//	snapshot_ids map[string]string - IDs of the created snapshots
 type StepSnapshotVolumes struct {
 	PollingConfig   *awscommon.AWSPollingConfig
 	LaunchDevices   []*ec2.BlockDeviceMapping

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -93,6 +93,10 @@ type Config struct {
 	// [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
 	// for more information. Defaults to legacy.
 	IMDSSupport string `mapstructure:"imds_support" required:"false"`
+	// NitroTPM Support. Valid options are `v2.0`. See the documentation on
+	// [NitroTPM Support](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enable-nitrotpm-support-on-ami.html) for
+	// more information. Only enabled if a valid option is provided, otherwise ignored.
+	TpmSupport string `mapstructure:"tpm_support" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -240,6 +244,10 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if b.config.IMDSSupport != "" && b.config.IMDSSupport != ec2.ImdsSupportValuesV20 {
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid imds_support values are %q or the empty string`, ec2.ImdsSupportValuesV20))
+	}
+
+	if b.config.TpmSupport != "" && b.config.TpmSupport != ec2.TpmSupportValuesV20 {
+		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(`The only valid tpm_support values are %q or the empty string`, ec2.TpmSupportValuesV20))
 	}
 
 	if errs != nil && len(errs.Errors) > 0 {
@@ -441,6 +449,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			AMISkipBuildRegion:       b.config.AMISkipBuildRegion,
 			PollingConfig:            b.config.PollingConfig,
 			IMDSSupport:              b.config.IMDSSupport,
+			TpmSupport:               b.config.TpmSupport,
 		},
 		&awscommon.StepAMIRegionCopy{
 			AccessConfig:      &b.config.AccessConfig,

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -167,6 +167,7 @@ type FlatConfig struct {
 	X509KeyPath                               *string                                `mapstructure:"x509_key_path" required:"true" cty:"x509_key_path" hcl:"x509_key_path"`
 	X509UploadPath                            *string                                `mapstructure:"x509_upload_path" required:"false" cty:"x509_upload_path" hcl:"x509_upload_path"`
 	IMDSSupport                               *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
+	TpmSupport                                *string                                `mapstructure:"tpm_support" required:"false" cty:"tpm_support" hcl:"tpm_support"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -336,6 +337,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"x509_key_path":                &hcldec.AttrSpec{Name: "x509_key_path", Type: cty.String, Required: false},
 		"x509_upload_path":             &hcldec.AttrSpec{Name: "x509_upload_path", Type: cty.String, Required: false},
 		"imds_support":                 &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"tpm_support":                  &hcldec.AttrSpec{Name: "tpm_support", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/builder/instance/step_register_ami.go
+++ b/builder/instance/step_register_ami.go
@@ -19,6 +19,7 @@ type StepRegisterAMI struct {
 	EnableAMISriovNetSupport bool
 	AMISkipBuildRegion       bool
 	IMDSSupport              string
+	TpmSupport               string
 }
 
 func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
@@ -68,6 +69,9 @@ func (s *StepRegisterAMI) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 	if s.IMDSSupport != "" {
 		registerOpts.ImdsSupport = aws.String(s.IMDSSupport)
+	}
+	if s.TpmSupport != "" {
+		registerOpts.TpmSupport = aws.String(s.TpmSupport)
 	}
 
 	registerResp, err := ec2conn.RegisterImage(registerOpts)

--- a/docs-partials/builder/chroot/Config-not-required.mdx
+++ b/docs-partials/builder/chroot/Config-not-required.mdx
@@ -159,6 +159,10 @@
   more information. Defaults to `legacy-bios` when `ami_architecture` is `x86_64` and
   `uefi` when `ami_architecture` is `arm64`.
 
+- `tpm_support` (string) - The TPM Support mode. Valid options are `v2.0`. See the documentation on
+  [NitroTPM Support](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enable-nitrotpm-support-on-ami.html) for
+  more information. Defaults to `v2.0`.
+
 - `uefi_data` (string) - Base64 representation of the non-volatile UEFI variable store. For more information
   see [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/uefi-secure-boot-optionB.html).
 

--- a/post-processor/import/post-processor.go
+++ b/post-processor/import/post-processor.go
@@ -50,6 +50,7 @@ type Config struct {
 	Format          string            `mapstructure:"format"`
 	Architecture    string            `mapstructure:"architecture"`
 	BootMode        string            `mapstructure:"boot_mode"`
+	TpmSupport      string            `mapstructure:"tpm_support"`
 
 	ctx interpolate.Context
 }
@@ -136,6 +137,11 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	if p.config.BootMode != "legacy-bios" && p.config.BootMode != "uefi" {
 		errs = packersdk.MultiErrorAppend(
 			errs, fmt.Errorf("invalid boot mode '%s'. Only 'uefi' and 'legacy-bios' are allowed", p.config.BootMode))
+	}
+
+	if p.config.TpmSupport != "v2.0" {
+		errs = packersdk.MultiErrorAppend(
+			errs, fmt.Errorf("invalid tpm support value '%s'. Only 'v2.0' is allowed", p.config.TpmSupport))
 	}
 
 	if p.config.Architecture == "arm64" && p.config.BootMode != "uefi" {

--- a/post-processor/import/post-processor.hcl2spec.go
+++ b/post-processor/import/post-processor.hcl2spec.go
@@ -111,6 +111,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"format":                        &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
 		"architecture":                  &hcldec.AttrSpec{Name: "architecture", Type: cty.String, Required: false},
 		"boot_mode":                     &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
+		"tpm_support":                   &hcldec.AttrSpec{Name: "tpm_support", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
Adding AWS NitroTPM support to AMI. More information can be found here:
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enable-nitrotpm-support-on-ami.html
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enable-nitrotpm-prerequisites.html

There is a flag that is not currently supported by the Packer AMI Builder: `--tpm-support v2.0`

This update is meant to resolve that. I am not a packer plugin developer, but added what I believe to be the basic necessary code and tried my best to maintain the compatibility of the code based on the other options that are currently there. I want to see this feature as soon as possible so if there are updates that need to be made please let me know.

Both `go build` and `make dev` seem to work.

Testing results in the following output:
```bash
$ make test
go: downloading github.com/stretchr/testify v1.7.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
?   	github.com/hashicorp/packer-plugin-amazon	[no test files]
ok  	github.com/hashicorp/packer-plugin-amazon/builder/chroot	1.781s
ok  	github.com/hashicorp/packer-plugin-amazon/builder/common	0.520s
?   	github.com/hashicorp/packer-plugin-amazon/builder/common/awserrors	[no test files]
?   	github.com/hashicorp/packer-plugin-amazon/builder/common/ssm	[no test files]
ok  	github.com/hashicorp/packer-plugin-amazon/builder/ebs	5.617s
?   	github.com/hashicorp/packer-plugin-amazon/builder/ebs/acceptance	[no test files]
ok  	github.com/hashicorp/packer-plugin-amazon/builder/ebssurrogate	2.065s
ok  	github.com/hashicorp/packer-plugin-amazon/builder/ebsvolume	1.657s
ok  	github.com/hashicorp/packer-plugin-amazon/builder/instance	2.584s
ok  	github.com/hashicorp/packer-plugin-amazon/datasource/ami	1.382s
ok  	github.com/hashicorp/packer-plugin-amazon/datasource/parameterstore	1.011s
ok  	github.com/hashicorp/packer-plugin-amazon/datasource/secretsmanager	0.606s
?   	github.com/hashicorp/packer-plugin-amazon/post-processor/import	[no test files]
?   	github.com/hashicorp/packer-plugin-amazon/version	[no test files]
```

Closes https://github.com/hashicorp/packer-plugin-amazon/issues/314

