### PR TITLE
Uefi preferred boot mode check

### DIFF
--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -384,7 +384,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 
 	if b.config.BootMode != "" {
 		err := awscommon.IsValidBootMode(b.config.BootMode)
-		if !valid {
+		if err != nil {
 			errs = packersdk.MultiErrorAppend(errs, err)
 		}
 	}

--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -383,15 +383,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	if b.config.BootMode != "" {
-		valid := false
-		for _, validBootMode := range []string{"legacy-bios", "uefi"} {
-			if validBootMode == b.config.BootMode {
-				valid = true
-				break
-			}
-		}
+		err := awscommon.IsValidBootMode(b.config.BootMode)
 		if !valid {
-			errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid boot_mode values are "legacy-bios" and "uefi"`))
+			errs = packersdk.MultiErrorAppend(errs, err)
 		}
 	}
 

--- a/builder/common/boot_mode_validation.go
+++ b/builder/common/boot_mode_validation.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // IsValidBootMode checks that the bootmode is a value supported by AWS
 func IsValidBootMode(bootmode string) error {
-	validModes := []string{"legacy-bios", "uefi"}
+	validModes := []string{"legacy-bios", "uefi", "uefi-preferred"}
 
 	for _, mode := range validModes {
 		if bootmode == mode {
@@ -12,5 +12,5 @@ func IsValidBootMode(bootmode string) error {
 		}
 	}
 
-	return fmt.Errorf("invalid boot mode %q, valid values are either 'uefi' or 'legacy-bios'", bootmode)
+	return fmt.Errorf("invalid boot mode %q, valid values are either 'uefi', 'legacy-bios' or 'uefi-preferred'", bootmode)
 }

--- a/builder/common/boot_mode_validation.go
+++ b/builder/common/boot_mode_validation.go
@@ -1,0 +1,16 @@
+package common
+
+import "fmt"
+
+// IsValidBootMode checks that the bootmode is a value supported by AWS
+func IsValidBootMode(bootmode string) error {
+	validModes := []string{"legacy-bios", "uefi"}
+
+	for _, mode := range validModes {
+		if bootmode == mode {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid boot mode %q, valid values are either 'uefi' or 'legacy-bios'", bootmode)
+}

--- a/builder/common/boot_mode_validation_test.go
+++ b/builder/common/boot_mode_validation_test.go
@@ -1,0 +1,44 @@
+package common
+
+import "testing"
+
+func TestIsValidBuildMode(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		expectError bool
+	}{
+		{
+			"Valid value legacy-bios",
+			"legacy-bios",
+			false,
+		},
+		{
+			"Valid value uefi",
+			"uefi",
+			false,
+		},
+		{
+			"Valid value uefi-preferred",
+			"uefi-preferred",
+			false,
+		},
+		{
+			"Invalid value uefipreferred",
+			"uefipreferred",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := IsValidBootMode(tt.value)
+			if (err != nil) != tt.expectError {
+				t.Errorf("error mismatch, expected %t, got %t", tt.expectError, err != nil)
+				if err != nil {
+					t.Logf("got error: %s", err)
+				}
+			}
+		})
+	}
+}

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -192,7 +192,7 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	if b.config.BootMode != "" {
 		err := awscommon.IsValidBootMode(b.config.BootMode)
 		if err != nil {
-			errs = packersdk.MultiErrorAppend(errs, err))
+			errs = packersdk.MultiErrorAppend(errs, err)
 		}
 	}
 

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -190,15 +190,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	if b.config.BootMode != "" {
-		valid := false
-		for _, validBootMode := range []string{"legacy-bios", "uefi"} {
-			if validBootMode == b.config.BootMode {
-				valid = true
-				break
-			}
-		}
-		if !valid {
-			errs = packersdk.MultiErrorAppend(errs, errors.New(`The only valid boot_mode values are "legacy-bios" and "uefi"`))
+		err := awscommon.IsValidBootMode(b.config.BootMode)
+		if err != nil {
+			errs = packersdk.MultiErrorAppend(errs, err))
 		}
 	}
 

--- a/post-processor/import/post-processor.go
+++ b/post-processor/import/post-processor.go
@@ -89,6 +89,8 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		p.config.Architecture = "x86_64"
 	}
 
+	errs := new(packersdk.MultiError)
+
 	if p.config.BootMode == "" {
 		// Graviton instance types run uefi by default
 		if p.config.Architecture == "arm64" {
@@ -96,9 +98,12 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 		} else {
 			p.config.BootMode = "legacy-bios"
 		}
+	} else {
+		err := awscommon.IsValidBootMode(p.config.BootMode)
+		if err != nil {
+			errs = packersdk.MultiErrorAppend(errs, err)
+		}
 	}
-
-	errs := new(packersdk.MultiError)
 
 	// Check and render s3_key_name
 	if err = interpolate.Validate(p.config.S3Key, &p.config.ctx); err != nil {


### PR DESCRIPTION
This PR refactors the boot check validation so all entities can use the same code to validate their option's value, and adds support for the `uefi-preferred` value.

Closes #340 

