### PR TITLE
Include only AMI's owned by caller during pre-validate

### DIFF
--- a/builder/common/step_pre_validate.go
+++ b/builder/common/step_pre_validate.go
@@ -17,7 +17,6 @@ import (
 
 // StepPreValidate provides an opportunity to pre-validate any configuration for
 // the build before actually doing any time consuming work
-//
 type StepPreValidate struct {
 	DestAmiName        string
 	ForceDeregister    bool
@@ -99,6 +98,7 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 
 	ui.Say(fmt.Sprintf("Prevalidating AMI Name: %s", s.DestAmiName))
 	req, resp := ec2conn.DescribeImagesRequest(&ec2.DescribeImagesInput{
+		Owners: []*string{aws.String("self")},
 		Filters: []*ec2.Filter{{
 			Name:   aws.String("name"),
 			Values: []*string{aws.String(s.DestAmiName)},


### PR DESCRIPTION
I maintain the [EKS-optimized AMI](https://github.com/awslabs/amazon-eks-ami), and as a result I build a lot of AMI's. 😄 

Our current naming convention for AMI's uses a date of the form `YYYYMMDD`. For better or worse, that's what we do. We have internal processes that build AMI's using this naming convention, and subsequently grant permissions for those AMI's to various other AWS accounts.

The pre-validate step in the `amazon-ebs` builder will fail if any existing AMI returned by a `ec2.DescribeImages` call uses the proposed name. This makes sense, because the later `ec2.CreateImage` call will fail with a `InvalidAMIName.Duplicate` code if there is such a collision, after we've already executed the time-consuming steps.

But, this `ec2.CreateImage` error only occurs when the *caller* has an existing AMI with the same name, whereas the pre-validate step currently fails even when an existing AMI that the caller has launch permissions for uses the same name (including public AMI's).

This PR modifies the pre-validate step to only check for existing AMI's that are owned by the caller.