### PR TITLE
github: fix pathing issues for building binaries

### DIFF
--- a/.github/actions/build-and-persist-plugin-binary/action.yml
+++ b/.github/actions/build-and-persist-plugin-binary/action.yml
@@ -17,4 +17,4 @@ runs:
     shell: bash
   - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
     with:
-      path: "././pkg/"
+      path: "pkg/"

--- a/.github/workflows/build_plugin_binaries.yml
+++ b/.github/workflows/build_plugin_binaries.yml
@@ -96,4 +96,4 @@ jobs:
           path: "."
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          path: "./pkg/"
+          path: "pkg/"


### PR DESCRIPTION
Running the actions to upload binaries fails with a pathing issue since relative pathing is unsupported for the upload-artifact action.