### PR TITLE
workflows: publish all the pkg files separately

### DIFF
--- a/.github/actions/build-and-persist-plugin-binary/action.yml
+++ b/.github/actions/build-and-persist-plugin-binary/action.yml
@@ -17,4 +17,4 @@ runs:
     shell: bash
   - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
     with:
-      path: "pkg/"
+      path: "pkg/*"

--- a/.github/workflows/build_plugin_binaries.yml
+++ b/.github/workflows/build_plugin_binaries.yml
@@ -79,21 +79,3 @@ jobs:
       - uses: "./.github/actions/build-and-persist-plugin-binary"
         with:
           GOOS: windows
-  store_artifacts:
-    runs-on: ubuntu-latest
-    container:
-      image: docker.mirror.hashicorp.services/cimg/go:1.18
-    needs:
-      - build_darwin
-      - build_freebsd
-      - build_linux
-      - build_openbsd
-      - build_solaris
-      - build_windows
-    steps:
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          path: "."
-      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          path: "pkg/"


### PR DESCRIPTION
The build_plugin_binaries workflow was pushing all the packages as one zip containing all the built binaries. To avoid this, we change the upload pattern so they all end-up as separate zip files instead in the actions, and skip the last aggregation/upload step.