### PR TITLE
actions: upload artifact with a name

### DIFF
--- a/.github/actions/build-and-persist-plugin-binary/action.yml
+++ b/.github/actions/build-and-persist-plugin-binary/action.yml
@@ -17,4 +17,5 @@ runs:
     shell: bash
   - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
     with:
-      path: "pkg/*"
+      name: "packer_plugin_amazon_${{ inputs.GOOS }}_${{ inputs.GOARCH }}.zip"
+      path: "pkg/packer_plugin_amazon_${{ inputs.GOOS }}_${{ inputs.GOARCH }}.zip"


### PR DESCRIPTION
To avoid artifacts being uploaded to a single zip, we add a name in addition to the path from which to pick-up the file.