### PR TITLE
Add support for KMS keys in the aws-cn partition

### DIFF
--- a/builder/common/ami_config.go
+++ b/builder/common/ami_config.go
@@ -322,7 +322,7 @@ func ValidateKmsKey(kmsKey string) (valid bool) {
 	}
 
 	// Check if kmsKey is the full ARN
-	kmsArnStartPattern := `^arn:aws(-us-gov)?:kms:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12}):`
+	kmsArnStartPattern := `^arn:aws(-[a-z]{2}(-gov)?)?:kms:([a-z]{2}-(gov-)?[a-z]+-\d{1})?:(\d{12}):`
 	if regexp.MustCompile(fmt.Sprintf("%skey/%s", kmsArnStartPattern, kmsKeyIdPattern)).MatchString(kmsKey) {
 		return true
 	}

--- a/builder/common/ami_config_test.go
+++ b/builder/common/ami_config_test.go
@@ -214,6 +214,7 @@ func TestAMIConfigPrepare_ValidateKmsKey(t *testing.T) {
 		"arn:aws:kms:us-east-1:012345678910:key/mrk-12345678-1234-abcd-0000-123456789012",
 		"arn:aws:kms:us-east-1:012345678910:key/mrk-f4224f9362ac4ed2b32a6bc77cf43510",
 		"arn:aws-us-gov:kms:us-gov-east-1:123456789012:key/12345678-1234-abcd-0000-123456789012",
+		"arn:aws-cn:kms:cn-north-1:012345678910:alias/my-alias",
 	}
 	for _, validCase := range validCases {
 		c.AMIKmsKeyId = validCase
@@ -233,6 +234,7 @@ func TestAMIConfigPrepare_ValidateKmsKey(t *testing.T) {
 		"arn:aws:kms:us-east-1:012345678910:key/zab-12345678-1234-abcd-0000-123456789012",
 		"arn:aws:kms:us-east-1:012345678910:key/mkr-12345678-1234-abcd-0000-123456789012",
 		"arn:foo:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef",
+		"arn:aws-gov:kms:cn-north-1:012345678910:alias/my-alias",
 	}
 	for _, invalidCase := range invalidCases {
 		c.AMIKmsKeyId = invalidCase


### PR DESCRIPTION
Closes: #356

```
~>  make test
?   	github.com/hashicorp/packer-plugin-amazon	[no test files]
ok  	github.com/hashicorp/packer-plugin-amazon/builder/chroot	7.391s
ok  	github.com/hashicorp/packer-plugin-amazon/builder/common	11.286s
?   	github.com/hashicorp/packer-plugin-amazon/builder/common/awserrors	[no test files]
?   	github.com/hashicorp/packer-plugin-amazon/builder/common/ssm	[no test files]
ok  	github.com/hashicorp/packer-plugin-amazon/builder/ebs	13.355s
?   	github.com/hashicorp/packer-plugin-amazon/builder/ebs/acceptance	[no test files]
ok  	github.com/hashicorp/packer-plugin-amazon/builder/ebssurrogate	11.938s
ok  	github.com/hashicorp/packer-plugin-amazon/builder/ebsvolume	11.874s
ok  	github.com/hashicorp/packer-plugin-amazon/builder/instance	9.491s
ok  	github.com/hashicorp/packer-plugin-amazon/datasource/ami	5.772s
ok  	github.com/hashicorp/packer-plugin-amazon/datasource/parameterstore	7.485s
ok  	github.com/hashicorp/packer-plugin-amazon/datasource/secretsmanager	4.609s
?   	github.com/hashicorp/packer-plugin-amazon/post-processor/import	[no test files]
?   	github.com/hashicorp/packer-plugin-amazon/version	[no test files]
```
