### PR TITLE
.gitignore: ignore crash.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ packer-plugin-amazon
 .docs
 .DS_Store
 *.sw*
+crash.log


### PR DESCRIPTION
The crash.log file is an artifact from testing, and should not be tracked by Git.