### PR TITLE
Fix docs for fast launch

### DIFF
--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -83,6 +83,8 @@ type Config struct {
 	//
 	// Fast launch is only relevant for Windows AMIs, and should not be used
 	// for other OSes.
+	// See the [Fast Launch Configuration](#fast-launch-config) section for
+	// information on the attributes supported for this block.
 	FastLaunch FastLaunchConfig `mapstructure:"fast_launch" required:"false"`
 
 	ctx interpolate.Context

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -12,6 +12,12 @@
   
   * ec2:DescribeVpcs
   * ec2:DescribeSubnets
+  
+  Additionally, since we filter subnets/AZs by their capability to host
+  an instance of the selected type, you may also want to define the
+  `ec2:DescribeInstanceTypeOfferings` action to the role running the build.
+  Otherwise, Packer will pick the most available subnet in the VPC selected,
+  which may not be able to host the instance type you provided.
 
 - `availability_zone` (string) - Destination availability zone to launch
   instance in. Leave this empty to allow Amazon to auto-assign.

--- a/docs-partials/builder/ebs/Config-not-required.mdx
+++ b/docs-partials/builder/ebs/Config-not-required.mdx
@@ -48,5 +48,7 @@
   
   Fast launch is only relevant for Windows AMIs, and should not be used
   for other OSes.
+  See the [Fast Launch Configuration](#fast-launch-config) section for
+  information on the attributes supported for this block.
 
 <!-- End of code generated from the comments of the Config struct in builder/ebs/builder.go; -->

--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -265,6 +265,14 @@ Linux](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html)
 or [for
 Windows](http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/finding-an-ami.html).
 
+### Fast Launch Config
+
+@include 'builder/ebs/FastLaunchConfig.mdx'
+
+#### Optional
+
+@include 'builder/ebs/FastLaunchConfig-not-required.mdx'
+
 ## Accessing the Instance to Debug
 
 If you need to access the instance to debug for some reason, run the builder


### PR DESCRIPTION
The fast-launch configuration block was added a couple of versions ago, but its documentation was never added to the docs page for the plugin.

This PR fixes that problem.