### PR TITLE
docs: add public ip paragraph in IAM section

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -295,6 +295,9 @@ If you are using the `vpc_filter` option, you must also add:
 
     ec2:DescribeVpcs
 
+This permission may also be needed by the `associate_public_ip_address` option, if specified without a subnet.
+In this case the plugin will invoke `DescribeVpcs` to find information about the default VPC.
+
 ## Troubleshooting
 
 ### Attaching IAM Policies to Roles

--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -298,6 +298,13 @@ If you are using the `vpc_filter` option, you must also add:
 This permission may also be needed by the `associate_public_ip_address` option, if specified without a subnet.
 In this case the plugin will invoke `DescribeVpcs` to find information about the default VPC.
 
+When using `associate_public_ip_address` without a subnet, you will also benefit from having:
+
+    ec2:DescribeInstanceTypeOfferings
+
+This will ensure that the plugin will pick a subnet/AZ that can host the type of instance
+you're requesting in your template.
+
 ## Troubleshooting
 
 ### Attaching IAM Policies to Roles


### PR DESCRIPTION
Since the `associate_public_ip_address' attribute may need to use the `DescribeVpcs' permission in order to get the default VPC information, we add this explanation to the IAM section in the docs.