### PR TITLE
workflows: run awscli install with update flag

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -54,7 +54,7 @@ jobs:
           cd /tmp
           curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
           unzip awscliv2.zip
-          ./aws/install
+          ./aws/install --update
           curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
           dpkg -i session-manager-plugin.deb
           rm -f session-manager-plugin.deb awscliv2.zip


### PR DESCRIPTION
When running the action to run the acceptance tests, the step to install the AWS cli fails since there's already a version installed.

To prevent this from making the action fail, we invoke the installation script with the `--update' flag, so it will override the current version with the latest from Amazon.