### PR TITLE
workflows: reference secrets not as env vars

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -51,10 +51,10 @@ jobs:
           make dev
       - uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2
         with:
-          aws-access-key-id: "${{ env.AWS_ACC_TEST_KEY_ID }}"
-          aws-secret-access-key: "${{ env.AWS_ACC_TEST_KEY_SECRET }}"
-          aws-region: "${{ env.AWS_ACC_TEST_REGION }}"
-          role-to-assume: "${{ env.AWS_ACC_TEST_ROLE }}"
+          aws-access-key-id: "${{ secrets.AWS_ACC_TEST_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.AWS_ACC_TEST_KEY_SECRET }}"
+          aws-region: "${{ secrets.AWS_ACC_TEST_REGION }}"
+          role-to-assume: "${{ secrets.AWS_ACC_TEST_ROLE }}"
           role-session-name: "packer-aws-acceptance-tests"
           role-duration-seconds: 14400 # 4h
       - run: |


### PR DESCRIPTION
The action to get temporary credentials for AWS was referring to secrets under `env', which resulted in the arguments for the action being empty, and therefore failing.