### PR TITLE
workflows: zip and keep logs for acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -64,3 +64,11 @@ jobs:
             -count 1 \
             -run "${{ github.event.inputs.run_pattern }}" \
             ./builder/ebs
+      - run: zip ebs_failure_logs.zip builder/ebs*txt
+        if: ${{ failure() }}
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        if: ${{ failure() }}
+        with:
+          name: "ebs_failure_logs.zip"
+          path: "ebs_failure_logs.zip"
+          retention-days: 5


### PR DESCRIPTION
When the acceptance tests fail for any reason, the logs of the failed run is kept as a text file in the builder's directory. Having access to those is important to diagnose what went wrong during the test run, so we add some extra steps to the job that runs them in order to compress and export them as artifact for the run.