### PR TITLE
feat: add ignore failure in ami datasource

### DIFF
--- a/builder/chroot/step_attach_volume.go
+++ b/builder/chroot/step_attach_volume.go
@@ -19,8 +19,9 @@ import (
 // available device location.
 //
 // Produces:
-//   device string - The location where the volume was attached.
-//   attach_cleanup CleanupFunc
+//
+//	device string - The location where the volume was attached.
+//	attach_cleanup CleanupFunc
 type StepAttachVolume struct {
 	PollingConfig *awscommon.AWSPollingConfig
 	attached      bool

--- a/builder/chroot/step_create_volume.go
+++ b/builder/chroot/step_create_volume.go
@@ -22,7 +22,8 @@ import (
 // device of the AMI.
 //
 // Produces:
-//   volume_id string - The ID of the created volume
+//
+//	volume_id string - The ID of the created volume
 type StepCreateVolume struct {
 	PollingConfig         *awscommon.AWSPollingConfig
 	volumeId              string

--- a/builder/chroot/step_flock.go
+++ b/builder/chroot/step_flock.go
@@ -17,7 +17,8 @@ import (
 // StepFlock provisions the instance within a chroot.
 //
 // Produces:
-//   flock_cleanup Cleanup - To perform early cleanup
+//
+//	flock_cleanup Cleanup - To perform early cleanup
 type StepFlock struct {
 	fh *os.File
 }

--- a/builder/chroot/step_mount_device.go
+++ b/builder/chroot/step_mount_device.go
@@ -27,8 +27,9 @@ type mountPathData struct {
 // StepMountDevice mounts the attached device.
 //
 // Produces:
-//   mount_path string - The location where the volume was mounted.
-//   mount_device_cleanup CleanupFunc - To perform early cleanup
+//
+//	mount_path string - The location where the volume was mounted.
+//	mount_device_cleanup CleanupFunc - To perform early cleanup
 type StepMountDevice struct {
 	MountOptions   []string
 	MountPartition string

--- a/builder/chroot/step_snapshot.go
+++ b/builder/chroot/step_snapshot.go
@@ -17,7 +17,8 @@ import (
 // StepSnapshot creates a snapshot of the created volume.
 //
 // Produces:
-//   snapshot_id string - ID of the created snapshot
+//
+//	snapshot_id string - ID of the created snapshot
 type StepSnapshot struct {
 	PollingConfig *awscommon.AWSPollingConfig
 	snapshotId    string

--- a/builder/common/access_config.go
+++ b/builder/common/access_config.go
@@ -35,26 +35,30 @@ import (
 // HCL config example:
 //
 // ```HCL
-// source "amazon-ebs" "example" {
-// 	assume_role {
-// 		role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-// 		session_name = "SESSION_NAME"
-// 		external_id  = "EXTERNAL_ID"
-// 	}
-// }
+//
+//	source "amazon-ebs" "example" {
+//		assume_role {
+//			role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+//			session_name = "SESSION_NAME"
+//			external_id  = "EXTERNAL_ID"
+//		}
+//	}
+//
 // ```
 //
 // JSON config example:
 //
 // ```json
-// builder{
-// 	"type": "amazon-ebs",
-// 	"assume_role": {
-// 		"role_arn"    :  "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
-// 		"session_name":  "SESSION_NAME",
-// 		"external_id" :  "EXTERNAL_ID"
-// 	}
-// }
+//
+//	builder{
+//		"type": "amazon-ebs",
+//		"assume_role": {
+//			"role_arn"    :  "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
+//			"session_name":  "SESSION_NAME",
+//			"external_id" :  "EXTERNAL_ID"
+//		}
+//	}
+//
 // ```
 type AssumeRoleConfig struct {
 	// Amazon Resource Name (ARN) of the IAM Role to assume.

--- a/builder/common/awserrors/utils.go
+++ b/builder/common/awserrors/utils.go
@@ -10,9 +10,9 @@ import (
 )
 
 // Returns true if the err matches all these conditions:
-//  * err is of type awserr.Error
-//  * Error.Code() matches code
-//  * Error.Message() contains message
+//   - err is of type awserr.Error
+//   - Error.Code() matches code
+//   - Error.Message() contains message
 func Matches(err error, code string, message string) bool {
 	if err, ok := err.(awserr.Error); ok {
 		return err.Code() == code && strings.Contains(err.Message(), message)

--- a/builder/common/block_device.go
+++ b/builder/common/block_device.go
@@ -36,21 +36,25 @@ const (
 // HCL2 example:
 //
 // ```hcl
-// launch_block_device_mappings {
-//     device_name = "/dev/sda1"
-//     encrypted = true
-//     kms_key_id = "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
-// }
+//
+//	launch_block_device_mappings {
+//	    device_name = "/dev/sda1"
+//	    encrypted = true
+//	    kms_key_id = "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
+//	}
+//
 // ```
 //
 // JSON example:
 // ```json
 // "launch_block_device_mappings": [
-//   {
-//      "device_name": "/dev/sda1",
-//      "encrypted": true,
-//      "kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
-//   }
+//
+//	{
+//	   "device_name": "/dev/sda1",
+//	   "encrypted": true,
+//	   "kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
+//	}
+//
 // ]
 // ```
 //
@@ -59,7 +63,6 @@ const (
 //
 // Documentation for Block Devices Mappings can be found here:
 // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concepts.html
-//
 type BlockDevice struct {
 	// Indicates whether the EBS volume is deleted on instance termination.
 	// Default false. NOTE: If this value is not explicitly set to true and

--- a/builder/common/step_pre_validate_test.go
+++ b/builder/common/step_pre_validate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-//DescribeVpcs mocks an ec2.DescribeVpcsOutput for a given input
+// DescribeVpcs mocks an ec2.DescribeVpcsOutput for a given input
 func (m *mockEC2Conn) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
 
 	if input == nil || aws.StringValue(input.VpcIds[0]) == "" {

--- a/builder/common/step_source_ami_info.go
+++ b/builder/common/step_source_ami_info.go
@@ -19,7 +19,8 @@ import (
 // that is used throughout the AMI creation process.
 //
 // Produces:
-//   source_image *ec2.Image - the source AMI info
+//
+//	source_image *ec2.Image - the source AMI info
 type StepSourceAMIInfo struct {
 	SourceAmi                string
 	EnableAMISriovNetSupport bool

--- a/builder/ebssurrogate/step_snapshot_volumes.go
+++ b/builder/ebssurrogate/step_snapshot_volumes.go
@@ -21,7 +21,8 @@ import (
 // StepSnapshotVolumes creates snapshots of the created volumes.
 //
 // Produces:
-//   snapshot_ids map[string]string - IDs of the created snapshots
+//
+//	snapshot_ids map[string]string - IDs of the created snapshots
 type StepSnapshotVolumes struct {
 	PollingConfig   *awscommon.AWSPollingConfig
 	LaunchDevices   []*ec2.BlockDeviceMapping

--- a/datasource/ami/data.go
+++ b/datasource/ami/data.go
@@ -27,6 +27,8 @@ type Config struct {
 	common.PackerConfig        `mapstructure:",squash"`
 	awscommon.AccessConfig     `mapstructure:",squash"`
 	awscommon.AmiFilterOptions `mapstructure:",squash"`
+	// If ami not found, return nil.
+	IgnoreFailures bool `mapstructure:"ignore_failure"`
 }
 
 func (d *Datasource) ConfigSpec() hcldec.ObjectSpec {
@@ -82,6 +84,9 @@ func (d *Datasource) Execute() (cty.Value, error) {
 
 	image, err := d.config.AmiFilterOptions.GetFilteredImage(&ec2.DescribeImagesInput{}, ec2.New(session))
 	if err != nil {
+		if d.config.IgnoreFailures {
+			return cty.NullVal(cty.EmptyObject), nil
+		}
 		return cty.NullVal(cty.EmptyObject), err
 	}
 

--- a/datasource/ami/data.hcl2spec.go
+++ b/datasource/ami/data.hcl2spec.go
@@ -38,6 +38,7 @@ type FlatConfig struct {
 	Filters               map[string]string                 `mapstructure:"filters" cty:"filters" hcl:"filters"`
 	Owners                []string                          `mapstructure:"owners" cty:"owners" hcl:"owners"`
 	MostRecent            *bool                             `mapstructure:"most_recent" cty:"most_recent" hcl:"most_recent"`
+	IgnoreFailures        *bool                             `mapstructure:"ignore_failure" cty:"ignore_failure" hcl:"ignore_failure"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -79,6 +80,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"filters":                       &hcldec.AttrSpec{Name: "filters", Type: cty.Map(cty.String), Required: false},
 		"owners":                        &hcldec.AttrSpec{Name: "owners", Type: cty.List(cty.String), Required: false},
 		"most_recent":                   &hcldec.AttrSpec{Name: "most_recent", Type: cty.Bool, Required: false},
+		"ignore_failure":                &hcldec.AttrSpec{Name: "ignore_failure", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/common/AssumeRoleConfig.mdx
+++ b/docs-partials/builder/common/AssumeRoleConfig.mdx
@@ -8,26 +8,30 @@ Usage example:
 HCL config example:
 
 ```HCL
-source "amazon-ebs" "example" {
-	assume_role {
-		role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
-		session_name = "SESSION_NAME"
-		external_id  = "EXTERNAL_ID"
+
+	source "amazon-ebs" "example" {
+		assume_role {
+			role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"
+			session_name = "SESSION_NAME"
+			external_id  = "EXTERNAL_ID"
+		}
 	}
-}
+
 ```
 
 JSON config example:
 
 ```json
-builder{
-	"type": "amazon-ebs",
-	"assume_role": {
-		"role_arn"    :  "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
-		"session_name":  "SESSION_NAME",
-		"external_id" :  "EXTERNAL_ID"
+
+	builder{
+		"type": "amazon-ebs",
+		"assume_role": {
+			"role_arn"    :  "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME",
+			"session_name":  "SESSION_NAME",
+			"external_id" :  "EXTERNAL_ID"
+		}
 	}
-}
+
 ```
 
 <!-- End of code generated from the comments of the AssumeRoleConfig struct in builder/common/access_config.go; -->

--- a/docs-partials/builder/common/BlockDevice.mdx
+++ b/docs-partials/builder/common/BlockDevice.mdx
@@ -11,21 +11,25 @@ build instance at launch using a specific non-default kms key:
 HCL2 example:
 
 ```hcl
-launch_block_device_mappings {
-    device_name = "/dev/sda1"
-    encrypted = true
-    kms_key_id = "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
-}
+
+	launch_block_device_mappings {
+	    device_name = "/dev/sda1"
+	    encrypted = true
+	    kms_key_id = "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
+	}
+
 ```
 
 JSON example:
 ```json
 "launch_block_device_mappings": [
-  {
-     "device_name": "/dev/sda1",
-     "encrypted": true,
-     "kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
-  }
+
+	{
+	   "device_name": "/dev/sda1",
+	   "encrypted": true,
+	   "kms_key_id": "1a2b3c4d-5e6f-1a2b-3c4d-5e6f1a2b3c4d"
+	}
+
 ]
 ```
 

--- a/docs-partials/datasource/ami/Config-not-required.mdx
+++ b/docs-partials/datasource/ami/Config-not-required.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the Config struct in datasource/ami/data.go; DO NOT EDIT MANUALLY -->
+
+- `ignore_failure` (bool) - If ami not found, return nil.
+
+<!-- End of code generated from the comments of the Config struct in datasource/ami/data.go; -->


### PR DESCRIPTION
1. Added `ignore_failure` flag to ami datasource:
- if `true` and the image not found -> returns `nil`
- else - same as current behavior.

Defaulted to `false`.

2. Some formatting required to pass github actions test.

Tests results:
``` 
$ make test
?       github.com/hashicorp/packer-plugin-amazon       [no test files]
ok      github.com/hashicorp/packer-plugin-amazon/builder/chroot        3.469s
ok      github.com/hashicorp/packer-plugin-amazon/builder/common        2.035s
?       github.com/hashicorp/packer-plugin-amazon/builder/common/awserrors      [no test files]
?       github.com/hashicorp/packer-plugin-amazon/builder/common/ssm    [no test files]
ok      github.com/hashicorp/packer-plugin-amazon/builder/ebs   13.905s
?       github.com/hashicorp/packer-plugin-amazon/builder/ebs/acceptance        [no test files]
ok      github.com/hashicorp/packer-plugin-amazon/builder/ebssurrogate  4.812s
ok      github.com/hashicorp/packer-plugin-amazon/builder/ebsvolume     3.097s
ok      github.com/hashicorp/packer-plugin-amazon/builder/instance      4.228s
ok      github.com/hashicorp/packer-plugin-amazon/datasource/ami        2.356s
ok      github.com/hashicorp/packer-plugin-amazon/datasource/parameterstore     3.011s
ok      github.com/hashicorp/packer-plugin-amazon/datasource/secretsmanager     2.710s
?       github.com/hashicorp/packer-plugin-amazon/post-processor/import [no test files]
?       github.com/hashicorp/packer-plugin-amazon/version       [no test files]
```

Closes #387 