### PR TITLE
docs: add more permissions troubleshooting details

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -305,6 +305,14 @@ When using `associate_public_ip_address` without a subnet, you will also benefit
 This will ensure that the plugin will pick a subnet/AZ that can host the type of instance
 you're requesting in your template.
 
+If you are using the `deprecate_at` attribute in your templates, you will also need:
+
+    ec2:EnableImageDeprecation
+
+If you are using SSM to connect to the instance, and are specifying a private key file, you must also add:
+
+    ec2-instance-connect:SendSSHPublicKey
+
 ## Troubleshooting
 
 ### Attaching IAM Policies to Roles


### PR DESCRIPTION
While running acceptance tests on an account/role with the permission set specified in our docs, we had some failures because of missing permissions.

This commit adds some docs on those missing permissions when attempting to build AMIs with specific options turned on.