### PR TITLE
docs: add docs on fast-launch permissions

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -313,6 +313,12 @@ If you are using SSM to connect to the instance, and are specifying a private ke
 
     ec2-instance-connect:SendSSHPublicKey
 
+If you are building a Windows AMI, and want to enable fast-launch, you will also need:
+
+    ec2:EnableFastLaunch
+    ec2:DescribeLaunchTemplates
+    ec2:DescribeFastLaunchImages
+
 ## Troubleshooting
 
 ### Attaching IAM Policies to Roles


### PR DESCRIPTION
In addition to the rest of the permissions required, this PR adds the extra permissions required to be able to build Windows `fast-launch` images on EC2.