### PR TITLE
github: bump timeout duration for acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -58,11 +58,11 @@ jobs:
           aws-region: "${{ secrets.AWS_ACC_TEST_REGION }}"
           role-to-assume: "${{ secrets.AWS_ACC_TEST_ROLE }}"
           role-session-name: "packer-aws-acceptance-tests"
-          role-duration-seconds: 14400 # 4h
+          role-duration-seconds: 21600 # 6h
       - run: |
           echo "Testing with Go ${{ needs.get-go-version.outputs.go-version }}"
           PACKER_ACC=1 go test \
-            -timeout 3h \
+            -timeout 5h \
             -count 1 \
             -run "${{ github.event.inputs.run_pattern }}" \
             ./builder/ebs


### PR DESCRIPTION
Last run failed after ~3h runtime, which is dangerously close to the timeout previously set. While the logs don't show stack traces, it's possible they did timeout, so to highten their chances to finish the acutal tests, we bump the timeout to 5h, and raise the session duration for the token to 6h.