### PR TITLE
fixing text for IAM permission needed

### DIFF
--- a/docs/builders/index.mdx
+++ b/docs/builders/index.mdx
@@ -245,7 +245,7 @@ for the Amazon plugin to work:
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:CopyImage",
         "ec2:CreateImage",
-        "ec2:CreateKeypair",
+        "ec2:CreateKeyPair",
         "ec2:CreateSecurityGroup",
         "ec2:CreateSnapshot",
         "ec2:CreateTags",


### PR DESCRIPTION
There was an error for in the Visual Policy Editor when I copy/pasted the JSON and then went to view it, picture below.

![image](https://github.com/hashicorp/packer-plugin-amazon/assets/10230166/ae4ec67a-d0d7-450a-8779-229d2e12f3c7)

So, I found that it was a capitalization error with that permission, so I changed `ec2:CreateKeypair` to `ec2:CreateKeyPair`. (capital `p` in the `Pair` part of the word)



