### PR TITLE
builder: allow specifying hostId for placement

### DIFF
--- a/builder/common/run_config.hcl2spec.go
+++ b/builder/common/run_config.hcl2spec.go
@@ -116,6 +116,7 @@ func (*FlatMetadataOptions) HCL2Spec() map[string]hcldec.Spec {
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatPlacement struct {
 	HostResourceGroupArn *string `mapstructure:"host_resource_group_arn" required:"false" cty:"host_resource_group_arn" hcl:"host_resource_group_arn"`
+	HostId               *string `mapstructure:"host_id" required:"false" cty:"host_id" hcl:"host_id"`
 	Tenancy              *string `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
 }
 
@@ -132,6 +133,7 @@ func (*Placement) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spe
 func (*FlatPlacement) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"host_resource_group_arn": &hcldec.AttrSpec{Name: "host_resource_group_arn", Type: cty.String, Required: false},
+		"host_id":                 &hcldec.AttrSpec{Name: "host_id", Type: cty.String, Required: false},
 		"tenancy":                 &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},
 	}
 	return s

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -48,6 +48,7 @@ type StepRunSourceInstance struct {
 	Tags                              map[string]string
 	LicenseSpecifications             []LicenseSpecification
 	HostResourceGroupArn              string
+	HostId                            string
 	Tenancy                           string
 	UserData                          string
 	UserDataFile                      string
@@ -270,6 +271,10 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 
 	if s.HostResourceGroupArn != "" {
 		runOpts.Placement.HostResourceGroupArn = aws.String(s.HostResourceGroupArn)
+	}
+
+	if s.HostId != "" {
+		runOpts.Placement.HostId = aws.String(s.HostId)
 	}
 
 	if s.Tenancy != "" {

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -276,6 +276,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Tags:                              b.config.RunTags,
 			LicenseSpecifications:             b.config.LicenseSpecifications,
 			HostResourceGroupArn:              b.config.Placement.HostResourceGroupArn,
+			HostId:                            b.config.Placement.HostId,
 			Tenancy:                           tenancy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,

--- a/docs-partials/builder/common/Placement-not-required.mdx
+++ b/docs-partials/builder/common/Placement-not-required.mdx
@@ -2,6 +2,8 @@
 
 - `host_resource_group_arn` (string) - The ARN of the host resource group in which to launch the instances.
 
+- `host_id` (string) - The ID of the host used when Packer launches an EC2 instance.
+
 - `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
   when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
   


### PR DESCRIPTION
This PR adds support for specifying an exact dedicated host ID in the placement block. We were originally running this when `mac2.metal` instances weren't publicly available and AWS API behaviour around them was weird enough that Packer couldn't see them in responses that didn't query a specific ID.

This addresses a specific issue we experience - since by default, the source will grab whatever the first available host is, we occasionally find ourselves with the problem of Packer "stealing" from the wrong pool because for various lifecycle reasons, another host was available. With this change, an end user can instead provide a specific host ID (e.g. via a variable, from the response of an external call to the AWS API creating a new dedicated host resource), ensuring that the correct host is used for a Packer build for resources that aren't possible to fully manage on demand - ideal for Mac type instances in AWS.

This should potentially be exclusive with `HostResourceGroupArn` but I'm not sure how to appropriately model that in a Packer plugin, or whether it's at all necessary.