### PR TITLE
common: add include_deprecated option to filters

### DIFF
--- a/.web-docs/components/data-source/ami/README.md
+++ b/.web-docs/components/data-source/ami/README.md
@@ -38,6 +38,10 @@ This selects the most recent Ubuntu 16.04 HVM EBS AMI from Canonical. Note that 
 - `most_recent` (bool) - Selects the newest created image when true.
   This is most useful for selecting a daily distro build.
 
+- `include_deprecated` (bool) - Include deprecated AMIs in the filtered response. Defaults to false.
+  If you are the AMI owner, deprecated AMIs appear in the response
+  regardless of what is specified for `include_deprecated`.
+
 <!-- End of code generated from the comments of the AmiFilterOptions struct in builder/common/ami_filter.go; -->
 
 

--- a/builder/common/ami_filter.go
+++ b/builder/common/ami_filter.go
@@ -25,6 +25,10 @@ type AmiFilterOptions struct {
 	// Selects the newest created image when true.
 	// This is most useful for selecting a daily distro build.
 	MostRecent bool `mapstructure:"most_recent"`
+	// Include deprecated AMIs in the filtered response. Defaults to false.
+	// If you are the AMI owner, deprecated AMIs appear in the response
+	// regardless of what is specified for `include_deprecated`.
+	IncludeDeprecated bool `mapstructure:"include_deprecated"`
 }
 
 func (d *AmiFilterOptions) GetOwners() []*string {
@@ -57,6 +61,8 @@ func (d *AmiFilterOptions) GetFilteredImage(params *ec2.DescribeImagesInput, ec2
 	if len(d.Owners) > 0 {
 		params.Owners = d.GetOwners()
 	}
+
+	params.IncludeDeprecated = &d.IncludeDeprecated
 
 	log.Printf("Using AMI Filters %v", params)
 	req, imageResp := ec2conn.DescribeImagesRequest(params)

--- a/builder/common/run_config.hcl2spec.go
+++ b/builder/common/run_config.hcl2spec.go
@@ -11,9 +11,10 @@ import (
 // FlatAmiFilterOptions is an auto-generated flat version of AmiFilterOptions.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatAmiFilterOptions struct {
-	Filters    map[string]string `mapstructure:"filters" cty:"filters" hcl:"filters"`
-	Owners     []string          `mapstructure:"owners" cty:"owners" hcl:"owners"`
-	MostRecent *bool             `mapstructure:"most_recent" cty:"most_recent" hcl:"most_recent"`
+	Filters           map[string]string `mapstructure:"filters" cty:"filters" hcl:"filters"`
+	Owners            []string          `mapstructure:"owners" cty:"owners" hcl:"owners"`
+	MostRecent        *bool             `mapstructure:"most_recent" cty:"most_recent" hcl:"most_recent"`
+	IncludeDeprecated *bool             `mapstructure:"include_deprecated" cty:"include_deprecated" hcl:"include_deprecated"`
 }
 
 // FlatMapstructure returns a new FlatAmiFilterOptions.
@@ -28,9 +29,10 @@ func (*AmiFilterOptions) FlatMapstructure() interface{ HCL2Spec() map[string]hcl
 // The decoded values from this spec will then be applied to a FlatAmiFilterOptions.
 func (*FlatAmiFilterOptions) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"filters":     &hcldec.AttrSpec{Name: "filters", Type: cty.Map(cty.String), Required: false},
-		"owners":      &hcldec.AttrSpec{Name: "owners", Type: cty.List(cty.String), Required: false},
-		"most_recent": &hcldec.AttrSpec{Name: "most_recent", Type: cty.Bool, Required: false},
+		"filters":            &hcldec.AttrSpec{Name: "filters", Type: cty.Map(cty.String), Required: false},
+		"owners":             &hcldec.AttrSpec{Name: "owners", Type: cty.List(cty.String), Required: false},
+		"most_recent":        &hcldec.AttrSpec{Name: "most_recent", Type: cty.Bool, Required: false},
+		"include_deprecated": &hcldec.AttrSpec{Name: "include_deprecated", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/builder/common/step_source_ami_info.go
+++ b/builder/common/step_source_ami_info.go
@@ -27,6 +27,7 @@ type StepSourceAMIInfo struct {
 	EnableAMIENASupport      confighelper.Trilean
 	AMIVirtType              string
 	AmiFilters               AmiFilterOptions
+	IncludeDeprecated        bool
 }
 
 type imageSort []*ec2.Image
@@ -50,7 +51,9 @@ func (s *StepSourceAMIInfo) Run(ctx context.Context, state multistep.StateBag) m
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	ui := state.Get("ui").(packersdk.Ui)
 
-	params := &ec2.DescribeImagesInput{}
+	params := &ec2.DescribeImagesInput{
+		IncludeDeprecated: &s.IncludeDeprecated,
+	}
 
 	if s.SourceAmi != "" {
 		params.ImageIds = []*string{&s.SourceAmi}

--- a/datasource/ami/data.hcl2spec.go
+++ b/datasource/ami/data.hcl2spec.go
@@ -38,6 +38,7 @@ type FlatConfig struct {
 	Filters               map[string]string                 `mapstructure:"filters" cty:"filters" hcl:"filters"`
 	Owners                []string                          `mapstructure:"owners" cty:"owners" hcl:"owners"`
 	MostRecent            *bool                             `mapstructure:"most_recent" cty:"most_recent" hcl:"most_recent"`
+	IncludeDeprecated     *bool                             `mapstructure:"include_deprecated" cty:"include_deprecated" hcl:"include_deprecated"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -79,6 +80,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"filters":                       &hcldec.AttrSpec{Name: "filters", Type: cty.Map(cty.String), Required: false},
 		"owners":                        &hcldec.AttrSpec{Name: "owners", Type: cty.List(cty.String), Required: false},
 		"most_recent":                   &hcldec.AttrSpec{Name: "most_recent", Type: cty.Bool, Required: false},
+		"include_deprecated":            &hcldec.AttrSpec{Name: "include_deprecated", Type: cty.Bool, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/common/AmiFilterOptions-not-required.mdx
+++ b/docs-partials/builder/common/AmiFilterOptions-not-required.mdx
@@ -13,4 +13,8 @@
 - `most_recent` (bool) - Selects the newest created image when true.
   This is most useful for selecting a daily distro build.
 
+- `include_deprecated` (bool) - Include deprecated AMIs in the filtered response. Defaults to false.
+  If you are the AMI owner, deprecated AMIs appear in the response
+  regardless of what is specified for `include_deprecated`.
+
 <!-- End of code generated from the comments of the AmiFilterOptions struct in builder/common/ami_filter.go; -->


### PR DESCRIPTION
When getting the AMIs to build a new image on, we never included deprecated AMIs, as is the default when describing images on AWS.

However, the request does offer this option, so we add this to the options to pick from when getting the base AMI.

Closes #403 

