### PR TITLE
ebs: skip_create_ami skips prevalidation of AMI name (#409)

### DIFF
--- a/builder/common/step_pre_validate.go
+++ b/builder/common/step_pre_validate.go
@@ -24,6 +24,7 @@ type StepPreValidate struct {
 	DestAmiName        string
 	ForceDeregister    bool
 	AMISkipBuildRegion bool
+	AMISkipCreateImage bool
 	VpcId              string
 	SubnetId           string
 	HasSubnetFilter    bool
@@ -86,6 +87,11 @@ func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) mul
 
 	if s.AMISkipBuildRegion {
 		ui.Say("skip_build_region was set; not prevalidating AMI name")
+		return multistep.ActionContinue
+	}
+
+	if s.AMISkipCreateImage {
+		ui.Say("skip_create_ami was set; not prevalidating AMI name")
 		return multistep.ActionContinue
 	}
 

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -290,6 +290,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			DestAmiName:        b.config.AMIName,
 			ForceDeregister:    b.config.AMIForceDeregister,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+			AMISkipCreateImage: b.config.AMISkipCreateImage,
 			VpcId:              b.config.VpcId,
 			SubnetId:           b.config.SubnetId,
 			HasSubnetFilter:    !b.config.SubnetFilter.Empty(),


### PR DESCRIPTION
Pretty simple fix that just adds a conditional to the **step_pre_validate** to skip it in case the skip_create_ami flag is set to true. I kept the look and format consistent with the existing skips that were already present.

Closes #409 

