### PR TITLE
docs: Add working example for enabling metadata service v2

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -33,7 +33,7 @@ references for [AMI](#ami-configuration),
 configuration references, which are
 necessary for this build to succeed and can be found further down the page.
 
-### Optional:
+**Optional:**
 
 <!-- Code generated from the comments of the Config struct in builder/ebs/builder.go; DO NOT EDIT MANUALLY -->
 
@@ -93,7 +93,7 @@ necessary for this build to succeed and can be found further down the page.
 
 ### AMI Configuration
 
-#### Required:
+**Required:**
 
 <!-- Code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; DO NOT EDIT MANUALLY -->
 
@@ -105,7 +105,7 @@ necessary for this build to succeed and can be found further down the page.
 <!-- End of code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; -->
 
 
-#### Optional:
+**Optional:**
 
 <!-- Code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; DO NOT EDIT MANUALLY -->
 
@@ -272,7 +272,7 @@ necessary for this build to succeed and can be found further down the page.
 
 ### Access Configuration
 
-#### Required:
+**Required:**
 
 <!-- Code generated from the comments of the AccessConfig struct in builder/common/access_config.go; DO NOT EDIT MANUALLY -->
 
@@ -291,7 +291,7 @@ necessary for this build to succeed and can be found further down the page.
 <!-- End of code generated from the comments of the AccessConfig struct in builder/common/access_config.go; -->
 
 
-#### Optional:
+**Optional:**
 
 <!-- Code generated from the comments of the AccessConfig struct in builder/common/access_config.go; DO NOT EDIT MANUALLY -->
 
@@ -501,7 +501,7 @@ JSON example:
 
 ### Run Configuration
 
-#### Required:
+**Required:**
 
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
@@ -515,7 +515,7 @@ JSON example:
 <!-- End of code generated from the comments of the RunConfig struct in builder/common/run_config.go; -->
 
 
-#### Optional:
+**Optional:**
 
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
@@ -1143,6 +1143,29 @@ source "amazon-ebs" "basic-example" {
 }
 ```
 
+##### Enforce Instance Metadata Service v2
+
+The Amazon builder has support for enforcing metadata service v2 (imdsv2) on a running instance and on the resulting AMI generated from a Packer build. 
+To enable support for both there are two key attributes that must be defined. 
+
+**HCL2**
+
+```hcl
+source "amazon-ebs" "basic-example" {
+  region        =  "us-east-1"
+  source_ami    =  "ami-fce3c696"
+  instance_type =  "t2.micro"
+  ssh_username  =  "ubuntu"
+  ami_name      =  "packer_AWS_example_{{timestamp}}"
+  # enforces imdsv2 support on the running instance being provisioned by Packer
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "required"
+    http_put_response_hop_limit = 1
+  }
+  imds_support  = "v2.0" # enforces imdsv2 support on the resulting AMI
+}
+```
 
 ### Session Manager Connections
 
@@ -1307,7 +1330,7 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
 <!-- End of code generated from the comments of the BlockDevice struct in builder/common/block_device.go; -->
 
 
-#### Optional:
+**Optional:**
 
 <!-- Code generated from the comments of the BlockDevice struct in builder/common/block_device.go; DO NOT EDIT MANUALLY -->
 
@@ -1364,7 +1387,7 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
 
 ### Communicator Configuration
 
-#### Optional:
+**Optional:**
 
 <!-- Code generated from the comments of the Config struct in communicator/config.go; DO NOT EDIT MANUALLY -->
 
@@ -1642,7 +1665,7 @@ https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launc
 <!-- End of code generated from the comments of the FastLaunchConfig struct in builder/ebs/fast_launch_setup.go; -->
 
 
-#### Optional
+**Optional:**
 
 <!-- Code generated from the comments of the FastLaunchConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
 

--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -45,17 +45,17 @@ references for [AMI](#ami-configuration),
 configuration references, which are
 necessary for this build to succeed and can be found further down the page.
 
-### Optional:
+**Optional:**
 
 @include 'builder/ebs/Config-not-required.mdx'
 
 ### AMI Configuration
 
-#### Required:
+**Required:**
 
 @include 'builder/common/AMIConfig-required.mdx'
 
-#### Optional:
+**Optional:**
 
 @include 'builder/common/AMIConfig-not-required.mdx'
 
@@ -63,11 +63,11 @@ necessary for this build to succeed and can be found further down the page.
 
 ### Access Configuration
 
-#### Required:
+**Required:**
 
 @include 'builder/common/AccessConfig-required.mdx'
 
-#### Optional:
+**Optional:**
 
 @include 'builder/common/AccessConfig-not-required.mdx'
 
@@ -85,11 +85,11 @@ necessary for this build to succeed and can be found further down the page.
 
 ### Run Configuration
 
-#### Required:
+**Required:**
 
 @include 'builder/common/RunConfig-required.mdx'
 
-#### Optional:
+**Optional:**
 
 @include 'builder/common/RunConfig-not-required.mdx'
 
@@ -146,6 +146,29 @@ source "amazon-ebs" "basic-example" {
 }
 ```
 
+##### Enforce Instance Metadata Service v2
+
+The Amazon builder has support for enforcing metadata service v2 (imdsv2) on a running instance and on the resulting AMI generated from a Packer build. 
+To enable support for both there are two key attributes that must be defined. 
+
+**HCL2**
+
+```hcl
+source "amazon-ebs" "basic-example" {
+  region        =  "us-east-1"
+  source_ami    =  "ami-fce3c696"
+  instance_type =  "t2.micro"
+  ssh_username  =  "ubuntu"
+  ami_name      =  "packer_AWS_example_{{timestamp}}"
+  # enforces imdsv2 support on the running instance being provisioned by Packer
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens = "required"
+    http_put_response_hop_limit = 1
+  }
+  imds_support  = "v2.0" # enforces imdsv2 support on the resulting AMI
+}
+```
 
 @include 'builders/aws-session-manager.mdx'
 
@@ -157,13 +180,13 @@ Block devices can be nested in the
 
 @include 'builder/common/BlockDevice.mdx'
 
-#### Optional:
+**Optional:**
 
 @include 'builder/common/BlockDevice-not-required.mdx'
 
 ### Communicator Configuration
 
-#### Optional:
+**Optional:**
 
 @include 'packer-plugin-sdk/communicator/Config-not-required.mdx'
 
@@ -261,7 +284,7 @@ Windows](http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/finding-an-ami.ht
 
 @include 'builder/ebs/FastLaunchConfig.mdx'
 
-#### Optional
+**Optional:**
 
 @include 'builder/ebs/FastLaunchConfig-not-required.mdx'
 

--- a/example/build.pkr.hcl
+++ b/example/build.pkr.hcl
@@ -5,14 +5,14 @@ packer {
   required_plugins {
     amazon = {
       version = ">= 1.0.0"
-      source = "github.com/hashicorp/amazon"
+      source  = "github.com/hashicorp/amazon"
     }
   }
 }
 
-data "amazon-ami" "ubuntu-xenial-1604-amd64" {
+data "amazon-ami" "ubuntu-jammy-amd64" {
   filters = {
-    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }
@@ -26,7 +26,7 @@ source "amazon-ebs" "basic-example" {
   ami_name      = "packer-example-${local.timestamp}"
   communicator  = "ssh"
   instance_type = "t2.micro"
-  source_ami    = data.amazon-ami.ubuntu-xenial-1604-amd64.id
+  source_ami    = data.amazon-ami.ubuntu-jammy-amd64.id
   ssh_username  = "ubuntu"
 }
 

--- a/example/instance-metadata/ubuntu-imdsv2-enabled.json
+++ b/example/instance-metadata/ubuntu-imdsv2-enabled.json
@@ -1,0 +1,41 @@
+{
+    "_comment": "Template used for testing issue 8157", 
+    "variables": {
+        "region": "us-east-1"
+    },
+    "builders": [
+        {
+            "type": "amazon-ebs",
+            "ami_name": "packer-example-{{ timestamp }}",
+            "region": "{{ user `region`}}",
+            "instance_type": "t2.micro",
+            "source_ami_filter": {
+                "filters": {
+                    "virtualization-type": "hvm",
+                    "name": "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*",
+                    "root-device-type": "ebs"
+                },
+                "owners": [
+                    "099720109477"
+                ],
+                "most_recent": true
+            },
+            "ssh_username": "ubuntu",
+            "communicator": "ssh",
+            "metadata_options":{ 
+                "http_endpoint" : "enabled", 
+                "http_tokens": "required", 
+                "http_put_response_hop_limit": 1
+            }, 
+            "imds_support":"v2.0"
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": [ "TOKEN=`curl -s -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\"` && curl -H \"X-aws-ec2-metadata-token: $TOKEN\" -s http://169.254.169.254/latest/meta-data/"]
+        }
+    ]
+  }
+  
+  

--- a/example/instance-metadata/ubuntu-imdsv2-enabled.pkr.hcl
+++ b/example/instance-metadata/ubuntu-imdsv2-enabled.pkr.hcl
@@ -1,0 +1,45 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+packer {
+  required_plugins {
+    amazon = {
+      version = "~>1"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+data "amazon-ami" "ubuntu-amd64" {
+  filters = {
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["099720109477"]
+}
+
+locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
+
+source "amazon-ebs" "imds-example" {
+  ami_name      = "packer-example-${local.timestamp}"
+  communicator  = "ssh"
+  instance_type = "t2.micro"
+  source_ami    = data.amazon-ami.ubuntu-amd64.id
+  ssh_username  = "ubuntu"
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+  imds_support = "v2.0"
+
+}
+
+build {
+  sources = ["source.amazon-ebs.imds-example"]
+      provisioner "shell" {
+        inline = ["TOKEN=`curl -s -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\"` && curl -H \"X-aws-ec2-metadata-token: $TOKEN\" -s http://169.254.169.254/latest/meta-data/"]
+      }
+}


### PR DESCRIPTION
- Add working example for enabling metadata service v2
- Update basic build to use non-deprecated ami
- Add documentation for enabling instance metadata v2

Closes #357
