### PR TITLE
Replace Xenial with Jammy image

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: "Compile/install the plugin on the current branch"
         run: |
           make dev
-      - uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2
+      - uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
           aws-access-key-id: "${{ secrets.AWS_ACC_TEST_KEY_ID }}"
           aws-secret-access-key: "${{ secrets.AWS_ACC_TEST_KEY_SECRET }}"

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -1524,7 +1524,7 @@ const testBuilderAccSessionManagerInterface = `
 		"source_ami_filter": {
 				"filters": {
 						"virtualization-type": "hvm",
-						"name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
+						"name": "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*",
 						"root-device-type": "ebs"
 				},
 				"owners": [

--- a/builder/ebs/test-fixtures/interpolated_run_tags.json
+++ b/builder/ebs/test-fixtures/interpolated_run_tags.json
@@ -10,7 +10,7 @@
             "source_ami_filter": {
                 "filters": {
                     "virtualization-type": "hvm",
-                    "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
+                    "name": "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*",
                     "root-device-type": "ebs"
                 },
                 "owners": [

--- a/builder/ebs/test-fixtures/interpolated_run_tags.pkr.hcl
+++ b/builder/ebs/test-fixtures/interpolated_run_tags.pkr.hcl
@@ -3,7 +3,7 @@
 
 data "amazon-ami" "test" {
   filters = {
-    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }

--- a/builder/ebs/test-fixtures/ssh-keys/ed25519_ssh_keypair.pkr.hcl
+++ b/builder/ebs/test-fixtures/ssh-keys/ed25519_ssh_keypair.pkr.hcl
@@ -3,7 +3,7 @@
 
 data "amazon-ami" "test" {
   filters = {
-    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }

--- a/builder/ebs/test-fixtures/ssh-keys/rsa_ssh_keypair.pkr.hcl
+++ b/builder/ebs/test-fixtures/ssh-keys/rsa_ssh_keypair.pkr.hcl
@@ -3,7 +3,7 @@
 
 data "amazon-ami" "test" {
   filters = {
-    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }

--- a/datasource/ami/test-fixtures/template.pkr.hcl
+++ b/datasource/ami/test-fixtures/template.pkr.hcl
@@ -3,7 +3,7 @@
 
 data "amazon-ami" "test" {
   filters = {
-    name                = "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*"
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
     root-device-type    = "ebs"
     virtualization-type = "hvm"
   }


### PR DESCRIPTION
This change updates the Ubuntu image in the Linux acceptance test to a non-deprecated Jammy 22.04 server. This change fixes the failing acceptance tests. 