### PR TITLE
feat: add platform flag for ec2 image import task

### DIFF
--- a/.web-docs/components/post-processor/import/README.md
+++ b/.web-docs/components/post-processor/import/README.md
@@ -94,7 +94,9 @@ Optional:
   must be set to  `uefi`.
 
 - `platform` (string) - The operating system of the virtual machine. One of:
-  `linux` or `windows`. This defaults to `linux`.
+  `linux` or `windows`. If `boot_mode` is set to `uefi` then this value must be 
+  set to either `windows` or `linux` depending on the operating system of the 
+  virtual machine.
 
 - `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
   provider whose API is compatible with aws EC2. Specify another endpoint

--- a/.web-docs/components/post-processor/import/README.md
+++ b/.web-docs/components/post-processor/import/README.md
@@ -93,6 +93,9 @@ Optional:
   `legacy-bios` or `uefi`. If `architecture` is set to `arm64` then this value
   must be set to  `uefi`.
 
+- `platform` (string) - The operating system of the virtual machine. One of:
+  `linux` or `windows`. This defaults to `linux`.
+
 - `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
   provider whose API is compatible with aws EC2. Specify another endpoint
   like this `https://ec2.custom.endpoint.com`.

--- a/docs/post-processors/import.mdx
+++ b/docs/post-processors/import.mdx
@@ -104,7 +104,9 @@ Optional:
   must be set to  `uefi`.
 
 - `platform` (string) - The operating system of the virtual machine. One of:
-  `linux` or `windows`. This defaults to `linux`.
+  `linux` or `windows`. If `boot_mode` is set to `uefi` then this value must be 
+  set to either `windows` or `linux` depending on the operating system of the 
+  virtual machine.
 
 - `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
   provider whose API is compatible with aws EC2. Specify another endpoint

--- a/docs/post-processors/import.mdx
+++ b/docs/post-processors/import.mdx
@@ -103,6 +103,9 @@ Optional:
   `legacy-bios` or `uefi`. If `architecture` is set to `arm64` then this value
   must be set to  `uefi`.
 
+- `platform` (string) - The operating system of the virtual machine. One of:
+  `linux` or `windows`. This defaults to `linux`.
+
 - `custom_endpoint_ec2` (string) - This option is useful if you use a cloud
   provider whose API is compatible with aws EC2. Specify another endpoint
   like this `https://ec2.custom.endpoint.com`.

--- a/post-processor/import/post-processor.go
+++ b/post-processor/import/post-processor.go
@@ -138,16 +138,16 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	}
 
 	switch p.config.Platform {
-	case "linux", "windows":
+	case "windows", "linux":
 	case "":
 		if p.config.BootMode == "uefi" {
-			errs = packersdk.MultiErrorAppend(errs, "'platform' must be set for 'uefi' image imports")
+			errs = packersdk.MultiErrorAppend(
+				errs, fmt.Errorf("invalid platform '%s', 'platform' must be set for 'uefi' image imports", p.config.Platform))
 		}
 	default:
 		errs = packersdk.MultiErrorAppend(errs, fmt.Errorf(
-			"invalid platform '%s'. Only 'linux' and 'windows' are allowed",
-			p.config.Platform))
-
+			"invalid platform '%s'. Only 'linux' and 'windows' are allowed", p.config.Platform))
+	}
 	if p.config.S3Encryption != "" && p.config.S3Encryption != "AES256" && p.config.S3Encryption != "aws:kms" {
 		errs = packersdk.MultiErrorAppend(
 			errs, fmt.Errorf("invalid s3 encryption format '%s'. Only 'AES256' and 'aws:kms' are allowed", p.config.S3Encryption))

--- a/post-processor/import/post-processor.go
+++ b/post-processor/import/post-processor.go
@@ -53,6 +53,7 @@ type Config struct {
 	Format          string            `mapstructure:"format"`
 	Architecture    string            `mapstructure:"architecture"`
 	BootMode        string            `mapstructure:"boot_mode"`
+	Platform        string            `mapstructure:"platform"`
 
 	ctx interpolate.Context
 }
@@ -90,6 +91,10 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 
 	if p.config.Architecture == "" {
 		p.config.Architecture = "x86_64"
+	}
+
+	if p.config.Platform == "" {
+		p.config.Platform = "linux"
 	}
 
 	errs := new(packersdk.MultiError)
@@ -144,6 +149,11 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 	if p.config.BootMode != "legacy-bios" && p.config.BootMode != "uefi" {
 		errs = packersdk.MultiErrorAppend(
 			errs, fmt.Errorf("invalid boot mode '%s'. Only 'uefi' and 'legacy-bios' are allowed", p.config.BootMode))
+	}
+
+	if p.config.Platform != "linux" && p.config.Platform != "windows" {
+		errs = packersdk.MultiErrorAppend(
+			errs, fmt.Errorf("invalid platform '%s'. Only 'linux' and 'windows' are allowed", p.config.Platform))
 	}
 
 	if p.config.Architecture == "arm64" && p.config.BootMode != "uefi" {
@@ -259,6 +269,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		},
 		Architecture: &p.config.Architecture,
 		BootMode:     &p.config.BootMode,
+		Platform:     &p.config.Platform,
 	}
 
 	if p.config.Encrypt && p.config.KMSKey != "" {

--- a/post-processor/import/post-processor.hcl2spec.go
+++ b/post-processor/import/post-processor.hcl2spec.go
@@ -54,6 +54,7 @@ type FlatConfig struct {
 	Format                *string                           `mapstructure:"format" cty:"format" hcl:"format"`
 	Architecture          *string                           `mapstructure:"architecture" cty:"architecture" hcl:"architecture"`
 	BootMode              *string                           `mapstructure:"boot_mode" cty:"boot_mode" hcl:"boot_mode"`
+	Platform              *string                           `mapstructure:"platform" cty:"platform" hcl:"platform"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -111,6 +112,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"format":                        &hcldec.AttrSpec{Name: "format", Type: cty.String, Required: false},
 		"architecture":                  &hcldec.AttrSpec{Name: "architecture", Type: cty.String, Required: false},
 		"boot_mode":                     &hcldec.AttrSpec{Name: "boot_mode", Type: cty.String, Required: false},
+		"platform":                      &hcldec.AttrSpec{Name: "platform", Type: cty.String, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
Setting platform for the image-import task fixes a bug where the process gets stuck as mentioned in #433 

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #433 

