### PR TITLE
common: doc fixes for kms regions

### DIFF
--- a/.web-docs/components/builder/chroot/README.md
+++ b/.web-docs/components/builder/chroot/README.md
@@ -342,8 +342,8 @@ builders.
 
 - `kms_key_id` (string) - ID, alias or ARN of the KMS key to use for AMI encryption. This
   only applies to the main `region` -- any regions the AMI gets copied to
-  copied will be encrypted by the default EBS KMS key for that region,
-  unless you set region-specific keys in AMIRegionKMSKeyIDs.
+  will be encrypted by the default EBS KMS key for that region,
+  unless you set region-specific keys in `region_kms_key_ids`.
   
   Set this value if you select `encrypt_boot`, but don't want to use the
   region's default KMS key.

--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -197,8 +197,8 @@ necessary for this build to succeed and can be found further down the page.
 
 - `kms_key_id` (string) - ID, alias or ARN of the KMS key to use for AMI encryption. This
   only applies to the main `region` -- any regions the AMI gets copied to
-  copied will be encrypted by the default EBS KMS key for that region,
-  unless you set region-specific keys in AMIRegionKMSKeyIDs.
+  will be encrypted by the default EBS KMS key for that region,
+  unless you set region-specific keys in `region_kms_key_ids`.
   
   Set this value if you select `encrypt_boot`, but don't want to use the
   region's default KMS key.

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -195,8 +195,8 @@ necessary for this build to succeed and can be found further down the page.
 
 - `kms_key_id` (string) - ID, alias or ARN of the KMS key to use for AMI encryption. This
   only applies to the main `region` -- any regions the AMI gets copied to
-  copied will be encrypted by the default EBS KMS key for that region,
-  unless you set region-specific keys in AMIRegionKMSKeyIDs.
+  will be encrypted by the default EBS KMS key for that region,
+  unless you set region-specific keys in `region_kms_key_ids`.
   
   Set this value if you select `encrypt_boot`, but don't want to use the
   region's default KMS key.

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -216,8 +216,8 @@ necessary for this build to succeed and can be found further down the page.
 
 - `kms_key_id` (string) - ID, alias or ARN of the KMS key to use for AMI encryption. This
   only applies to the main `region` -- any regions the AMI gets copied to
-  copied will be encrypted by the default EBS KMS key for that region,
-  unless you set region-specific keys in AMIRegionKMSKeyIDs.
+  will be encrypted by the default EBS KMS key for that region,
+  unless you set region-specific keys in `region_kms_key_ids`.
   
   Set this value if you select `encrypt_boot`, but don't want to use the
   region's default KMS key.

--- a/builder/common/ami_config.go
+++ b/builder/common/ami_config.go
@@ -110,8 +110,8 @@ type AMIConfig struct {
 	AMIEncryptBootVolume config.Trilean `mapstructure:"encrypt_boot" required:"false"`
 	// ID, alias or ARN of the KMS key to use for AMI encryption. This
 	// only applies to the main `region` -- any regions the AMI gets copied to
-	// copied will be encrypted by the default EBS KMS key for that region,
-	// unless you set region-specific keys in AMIRegionKMSKeyIDs.
+	// will be encrypted by the default EBS KMS key for that region,
+	// unless you set region-specific keys in `region_kms_key_ids`.
 	//
 	// Set this value if you select `encrypt_boot`, but don't want to use the
 	// region's default KMS key.
@@ -179,7 +179,7 @@ func (c *AMIConfig) Prepare(accessConfig *AccessConfig, ctx *interpolate.Context
 	}
 
 	// Make sure that if we have region_kms_key_ids defined,
-	//  the regions in region_kms_key_ids are also in ami_regions
+	// the regions in region_kms_key_ids are also in ami_regions
 	if len(c.AMIRegionKMSKeyIDs) > 0 {
 		for kmsKeyRegion := range c.AMIRegionKMSKeyIDs {
 			if !stringInSlice(c.AMIRegions, kmsKeyRegion) {

--- a/docs-partials/builder/common/AMIConfig-not-required.mdx
+++ b/docs-partials/builder/common/AMIConfig-not-required.mdx
@@ -88,8 +88,8 @@
 
 - `kms_key_id` (string) - ID, alias or ARN of the KMS key to use for AMI encryption. This
   only applies to the main `region` -- any regions the AMI gets copied to
-  copied will be encrypted by the default EBS KMS key for that region,
-  unless you set region-specific keys in AMIRegionKMSKeyIDs.
+  will be encrypted by the default EBS KMS key for that region,
+  unless you set region-specific keys in `region_kms_key_ids`.
   
   Set this value if you select `encrypt_boot`, but don't want to use the
   region's default KMS key.


### PR DESCRIPTION
As pointed out by a user on discuss, the region_kms_key_ids attribute was not referenced correctly in the documentation for kms_key_id.

This commit fixes this mistake, along with a typo in the documentation for `kms_key_id'.