### PR TITLE
Add more diags on fast-launch enable step

### DIFF
--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -1760,9 +1760,17 @@ build {
 `
 
 const testWindowsFastBoot = `
+data "amazon-ami" "windows-ami" {
+	filters = {
+		name = "Windows_Server-2016-English-Core-Base-*"
+	}
+	owners = ["801119661308"]
+	most_recent = true
+}
+
 source "amazon-ebs" "windows-fastboot" {
 	ami_name             = "%s"
-	source_ami           = "ami-0a967b5d9c7fa4630" # Windows server 2016 base x86_64
+	source_ami           = data.amazon-ami.windows-ami.id
 	instance_type        = "m3.medium"
 	region               = "us-east-1"
 	communicator         = "winrm"
@@ -1788,9 +1796,17 @@ build {
 `
 
 const testWindowsFastBootWithTemplateID = `
+data "amazon-ami" "windows-ami" {
+	filters = {
+		name = "Windows_Server-2016-English-Core-Base-*"
+	}
+	owners = ["801119661308"]
+	most_recent = true
+}
+
 source "amazon-ebs" "windows-fastboot" {
 	ami_name             = "%s"
-	source_ami           = "ami-0a967b5d9c7fa4630" # Windows server 2016 base x86_64
+	source_ami           = data.amazon-ami.windows-ami.id
 	instance_type        = "m3.medium"
 	region               = "us-east-1"
 	communicator         = "winrm"

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -1131,7 +1131,7 @@ func TestAccBuilder_EbsWindowsFastLaunch(t *testing.T) {
 					}
 
 					if *img.State != "enabled" {
-						return fmt.Errorf("expected fast-launch state to be enabled, but is %q", *img.State)
+						return fmt.Errorf("expected fast-launch state to be enabled, but is %q: transition state was %q", *img.State, *img.StateTransitionReason)
 					}
 
 					return nil

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -1083,7 +1083,7 @@ func TestAccBuilder_EbsWindowsFastLaunch(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			testcase := &acctest.PluginTestCase{
-				Name:     "amazon-ebs-windows-fastlaunch",
+				Name:     tt.name,
 				Template: tt.template,
 				Teardown: func() error {
 					return tt.ami.CleanUpAmi()

--- a/builder/ebs/step_enable_fast_launch.go
+++ b/builder/ebs/step_enable_fast_launch.go
@@ -40,6 +40,11 @@ func (s *stepEnableFastLaunch) Run(ctx context.Context, state multistep.StateBag
 	ec2conn := state.Get("ec2").(*ec2.EC2)
 	amis := state.Get("amis").(map[string]string)
 
+	if len(amis) == 0 {
+		ui.Say("No AMI found in state, skipping fast-launch setup...")
+		return multistep.ActionContinue
+	}
+
 	for _, ami := range amis {
 		ui.Say(fmt.Sprintf("Enabling fast boot for AMI %s", ami))
 


### PR DESCRIPTION
Following up on issue #445, this PR adds more diagnostics to the step that enables fast-launch.

Since the wait step only waited for the state to change to either "enabled", "enabled-failed" or "enabling-failed", but later on the code didn't check the state was indeed "enabled", we could end-up in a situation where the fast-launch step failed on AWS, but the plugin would count it as a success.
Note: I couldn't replicate such a scenario in my tests, but this remains a possibility, so I hope the community will someday share a template that we can adapt to ensure the plugin does take this into account.

Also, added some checks to signal the step is being skipped if no AMI's present in the plugin's state bag, as otherwise the step would silently succeed without doing anything.

Finally, we also fix the acceptance tests, as the AMI we picked for them did not exist anymore, and therefore would always fail.