### PR TITLE
fix: Finalize uefi-preferred use for amazon-import

### DIFF
--- a/post-processor/import/post-processor.go
+++ b/post-processor/import/post-processor.go
@@ -153,7 +153,7 @@ func (p *PostProcessor) Configure(raws ...interface{}) error {
 			errs, fmt.Errorf("invalid s3 encryption format '%s'. Only 'AES256' and 'aws:kms' are allowed", p.config.S3Encryption))
 	}
 
-	if p.config.BootMode != "legacy-bios" && p.config.BootMode != "uefi" {
+	if p.config.BootMode != "legacy-bios" && p.config.BootMode != "uefi" && p.config.BootMode != "uefi-preferred" {
 		errs = packersdk.MultiErrorAppend(
 			errs, fmt.Errorf("invalid boot mode '%s'. Only 'uefi' and 'legacy-bios' are allowed", p.config.BootMode))
 	}


### PR DESCRIPTION
Back in March in version 1.2.2 there was code added to the boot_mode_validation_test.go and various other validation files, uefi-preferred was allowed, but in  post-processor.go it was not allowed, atleast for the amazon-import.

Tests were already committed prior to 1.2.2 release

Existing Issues already closed

https://github.com/hashicorp/packer-plugin-amazon/issues/340
https://github.com/hashicorp/packer-plugin-amazon/issues/362

Built locally and tested. 

With this change I am now able to publish hybrid bios/efi images built from other packer provisioners and have them run on any ec2 instance type, ie t2 targeted for the free tier offering.
