### PR TITLE
ebs: add fast-launch support with AMI copies

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -1671,24 +1671,43 @@ https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launc
 
 - `enable_fast_launch` (bool) - Configure fast-launch for Windows AMIs
 
-- `template_id` (string) - The ID of the launch template to use for the fast launch
+- `template_id` (string) - The ID of the launch template to use for fast launch for the main AMI.
   
   This cannot be specified in conjunction with the template name.
   
   If no template is specified, the default launch template will be used,
   as specified in the AWS docs.
+  
+  If you copy the AMI to other regions, this option should not
+  be used, use instead the `fast_launch_template_config` option.
 
-- `template_name` (string) - The name of the launch template to use for fast launch
+- `template_name` (string) - The name of the launch template to use for fast launch for the main AMI.
   
   This cannot be specified in conjunction with the template ID.
   
   If no template is specified, the default launch template will be used,
   as specified in the AWS docs.
+  
+  If you copy the AMI to other regions, this option should not
+  be used, use instead the `fast_launch_template_config` option.
 
-- `template_version` (int) - The version of the launch template to use
+- `template_version` (int) - The version of the launch template to use for fast launch for the main AMI.
   
   If unspecified, and a template is referenced, this will default to
   the latest version available for the template.
+  
+  If you copy the AMI to other regions, this option should not
+  be used, use instead the `fast_launch_template_config` option.
+
+- `region_launch_templates` ([]FastLaunchTemplateConfig) - RegionLaunchTemplates is the list of launch templates per region.
+  
+  This should be specified if you want to use a custom launch
+  template for your fast-launched images, and you are copying
+  the image to other regions.
+  
+  Note: all the regions don't need an entry in this map, but if you
+  don't specify a region's template, a default one will be picked
+  by AWS.
 
 - `max_parallel_launches` (int) - Maximum number of instances to launch for creating pre-provisioned snapshots
   

--- a/builder/ebs/builder_test.go
+++ b/builder/ebs/builder_test.go
@@ -284,6 +284,36 @@ func TestBuilderPrepare_FastLaunch(t *testing.T) {
 			false,
 		},
 		{
+			"Error - regional launch template specified, with same region as top-level",
+			map[string]interface{}{
+				"fast_launch": map[string]interface{}{
+					"region_launch_templates": map[string]interface{}{
+						"region":           "us-east-1",
+						"template_name":    "name",
+						"template_version": 2,
+					},
+					"template_name":         "test",
+					"max_parallel_launches": 10,
+					"target_resource_count": 1,
+				},
+			},
+			true,
+		},
+		{
+			"Error - regional launch template specified, without region",
+			map[string]interface{}{
+				"fast_launch": map[string]interface{}{
+					"region_launch_templates": map[string]interface{}{
+						"template_name":    "name",
+						"template_version": 2,
+					},
+					"max_parallel_launches": 10,
+					"target_resource_count": 1,
+				},
+			},
+			true,
+		},
+		{
 			"Error - max parallel launches < 6",
 			map[string]interface{}{
 				"fast_launch": map[string]interface{}{

--- a/builder/ebs/fast_launch_setup.go
+++ b/builder/ebs/fast_launch_setup.go
@@ -2,20 +2,23 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:generate packer-sdc struct-markdown
-//go:generate packer-sdc mapstructure-to-hcl2 -type FastLaunchConfig
+//go:generate packer-sdc mapstructure-to-hcl2 -type FastLaunchConfig,FastLaunchTemplateConfig
 
 package ebs
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+)
 
-// FastLaunchConfig is the configuration for setting up fast-launch for Windows AMIs
+// FastLaunchTemplateConfig is the launch template configuration for a region.
 //
-// NOTE: requires the Windows image to be sysprep'd to enable fast-launch. See the
-// AWS docs for more information:
-// https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launch.html
-type FastLaunchConfig struct {
-	// Configure fast-launch for Windows AMIs
-	UseFastLaunch bool `mapstructure:"enable_fast_launch"`
+// This must be used if the configuration has more than one region specified
+// in the template, as each fast-launch enablement step occurs after the
+// copy, and each region may pick their own launch template.
+type FastLaunchTemplateConfig struct {
+	// The region in which to find the launch template to use
+	Region string `mapstructure:"region"`
 	// The ID of the launch template to use for the fast launch
 	//
 	// This cannot be specified in conjunction with the template name.
@@ -35,6 +38,83 @@ type FastLaunchConfig struct {
 	// If unspecified, and a template is referenced, this will default to
 	// the latest version available for the template.
 	LaunchTemplateVersion int `mapstructure:"template_version"`
+}
+
+func (tc *FastLaunchTemplateConfig) Prepare() []error {
+	var errs []error
+
+	if tc.Region == "" {
+		return append(errs, fmt.Errorf("region cannot be empty for a regional fast template config"))
+	}
+
+	if tc.LaunchTemplateID != "" && tc.LaunchTemplateName != "" {
+		errs = append(errs, fmt.Errorf("fast_launch_template_config region %q: both template ID and name cannot be specified at the same time", tc.Region))
+	}
+
+	if tc.LaunchTemplateVersion != 0 && tc.LaunchTemplateVersion < 1 {
+		errs = append(errs, fmt.Errorf("fast_launch_template_config region %q: the launch template version must be >= 1, provided value is %d", tc.Region, tc.LaunchTemplateVersion))
+	}
+
+	if tc.LaunchTemplateVersion != 0 && tc.LaunchTemplateID == "" && tc.LaunchTemplateName == "" {
+		errs = append(errs, fmt.Errorf("fast_launch_template_config region %q: launch template version specified without an ID or name", tc.Region))
+	}
+
+	return errs
+}
+
+// FastLaunchConfig is the configuration for setting up fast-launch for Windows AMIs
+//
+// NOTE: requires the Windows image to be sysprep'd to enable fast-launch. See the
+// AWS docs for more information:
+// https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launch.html
+type FastLaunchConfig struct {
+	// Configure fast-launch for Windows AMIs
+	UseFastLaunch bool `mapstructure:"enable_fast_launch"`
+	// The region in which the AMI will be built
+	//
+	// This is only set by the builder, and not by the client.
+	// Its only use is to move the launch template configuration if it has
+	// been specified into the map of region -> FastLaunchTemplateConfig
+	// for easier processing later.
+	defaultRegion string
+	// The ID of the launch template to use for fast launch for the main AMI.
+	//
+	// This cannot be specified in conjunction with the template name.
+	//
+	// If no template is specified, the default launch template will be used,
+	// as specified in the AWS docs.
+	//
+	// If you copy the AMI to other regions, this option should not
+	// be used, use instead the `fast_launch_template_config` option.
+	LaunchTemplateID string `mapstructure:"template_id"`
+	// The name of the launch template to use for fast launch for the main AMI.
+	//
+	// This cannot be specified in conjunction with the template ID.
+	//
+	// If no template is specified, the default launch template will be used,
+	// as specified in the AWS docs.
+	//
+	// If you copy the AMI to other regions, this option should not
+	// be used, use instead the `fast_launch_template_config` option.
+	LaunchTemplateName string `mapstructure:"template_name"`
+	// The version of the launch template to use for fast launch for the main AMI.
+	//
+	// If unspecified, and a template is referenced, this will default to
+	// the latest version available for the template.
+	//
+	// If you copy the AMI to other regions, this option should not
+	// be used, use instead the `fast_launch_template_config` option.
+	LaunchTemplateVersion int `mapstructure:"template_version"`
+	// RegionLaunchTemplates is the list of launch templates per region.
+	//
+	// This should be specified if you want to use a custom launch
+	// template for your fast-launched images, and you are copying
+	// the image to other regions.
+	//
+	// Note: all the regions don't need an entry in this map, but if you
+	// don't specify a region's template, a default one will be picked
+	// by AWS.
+	RegionLaunchTemplates []FastLaunchTemplateConfig `mapstructure:"region_launch_templates"`
 	// Maximum number of instances to launch for creating pre-provisioned snapshots
 	//
 	// If specified, must be a minimum of `6`
@@ -72,6 +152,10 @@ func (c FastLaunchConfig) isDefault() bool {
 		return false
 	}
 
+	if len(c.RegionLaunchTemplates) != 0 {
+		return false
+	}
+
 	return true
 }
 
@@ -93,16 +177,31 @@ func (c *FastLaunchConfig) Prepare() []error {
 		errs = append(errs, fmt.Errorf("target_resource_count must be >= 1, provided value is %d", c.TargetResourceCount))
 	}
 
-	if c.LaunchTemplateID != "" && c.LaunchTemplateName != "" {
-		errs = append(errs, fmt.Errorf("both template ID and name cannot be specified at the same time"))
+	if c.LaunchTemplateID != "" || c.LaunchTemplateName != "" || c.LaunchTemplateVersion != 0 {
+		log.Printf("[INFO] fast_launch: setting default region %q for top-level template config", c.defaultRegion)
+		c.RegionLaunchTemplates = append(c.RegionLaunchTemplates, FastLaunchTemplateConfig{
+			Region:                c.defaultRegion,
+			LaunchTemplateID:      c.LaunchTemplateID,
+			LaunchTemplateName:    c.LaunchTemplateName,
+			LaunchTemplateVersion: c.LaunchTemplateVersion,
+		})
 	}
 
-	if c.LaunchTemplateVersion != 0 && c.LaunchTemplateVersion < 1 {
-		errs = append(errs, fmt.Errorf("the launch template version must be >= 1, provided value is %d", c.LaunchTemplateVersion))
-	}
+	// Duplication check
+	regions := map[string]struct{}{}
 
-	if c.LaunchTemplateVersion != 0 && c.LaunchTemplateID == "" && c.LaunchTemplateName == "" {
-		errs = append(errs, fmt.Errorf("unsupported: launch template version specified without an ID or name"))
+	for _, templateConfig := range c.RegionLaunchTemplates {
+		_, ok := regions[templateConfig.Region]
+		if ok {
+			errs = append(errs, fmt.Errorf("fast launch: launch template specified twice for region %q, only once is supported", templateConfig.Region))
+		}
+
+		regions[templateConfig.Region] = struct{}{}
+
+		err := templateConfig.Prepare()
+		if err != nil {
+			errs = append(errs, err...)
+		}
 	}
 
 	return errs

--- a/builder/ebs/fast_launch_setup.hcl2spec.go
+++ b/builder/ebs/fast_launch_setup.hcl2spec.go
@@ -10,12 +10,13 @@ import (
 // FlatFastLaunchConfig is an auto-generated flat version of FastLaunchConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatFastLaunchConfig struct {
-	UseFastLaunch         *bool   `mapstructure:"enable_fast_launch" cty:"enable_fast_launch" hcl:"enable_fast_launch"`
-	LaunchTemplateID      *string `mapstructure:"template_id" cty:"template_id" hcl:"template_id"`
-	LaunchTemplateName    *string `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
-	LaunchTemplateVersion *int    `mapstructure:"template_version" cty:"template_version" hcl:"template_version"`
-	MaxParallelLaunches   *int    `mapstructure:"max_parallel_launches" cty:"max_parallel_launches" hcl:"max_parallel_launches"`
-	TargetResourceCount   *int    `mapstructure:"target_resource_count" cty:"target_resource_count" hcl:"target_resource_count"`
+	UseFastLaunch         *bool                          `mapstructure:"enable_fast_launch" cty:"enable_fast_launch" hcl:"enable_fast_launch"`
+	LaunchTemplateID      *string                        `mapstructure:"template_id" cty:"template_id" hcl:"template_id"`
+	LaunchTemplateName    *string                        `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
+	LaunchTemplateVersion *int                           `mapstructure:"template_version" cty:"template_version" hcl:"template_version"`
+	RegionLaunchTemplates []FlatFastLaunchTemplateConfig `mapstructure:"region_launch_templates" cty:"region_launch_templates" hcl:"region_launch_templates"`
+	MaxParallelLaunches   *int                           `mapstructure:"max_parallel_launches" cty:"max_parallel_launches" hcl:"max_parallel_launches"`
+	TargetResourceCount   *int                           `mapstructure:"target_resource_count" cty:"target_resource_count" hcl:"target_resource_count"`
 }
 
 // FlatMapstructure returns a new FlatFastLaunchConfig.
@@ -30,12 +31,42 @@ func (*FastLaunchConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcl
 // The decoded values from this spec will then be applied to a FlatFastLaunchConfig.
 func (*FlatFastLaunchConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"enable_fast_launch":    &hcldec.AttrSpec{Name: "enable_fast_launch", Type: cty.Bool, Required: false},
-		"template_id":           &hcldec.AttrSpec{Name: "template_id", Type: cty.String, Required: false},
-		"template_name":         &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
-		"template_version":      &hcldec.AttrSpec{Name: "template_version", Type: cty.Number, Required: false},
-		"max_parallel_launches": &hcldec.AttrSpec{Name: "max_parallel_launches", Type: cty.Number, Required: false},
-		"target_resource_count": &hcldec.AttrSpec{Name: "target_resource_count", Type: cty.Number, Required: false},
+		"enable_fast_launch":      &hcldec.AttrSpec{Name: "enable_fast_launch", Type: cty.Bool, Required: false},
+		"template_id":             &hcldec.AttrSpec{Name: "template_id", Type: cty.String, Required: false},
+		"template_name":           &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
+		"template_version":        &hcldec.AttrSpec{Name: "template_version", Type: cty.Number, Required: false},
+		"region_launch_templates": &hcldec.BlockListSpec{TypeName: "region_launch_templates", Nested: hcldec.ObjectSpec((*FlatFastLaunchTemplateConfig)(nil).HCL2Spec())},
+		"max_parallel_launches":   &hcldec.AttrSpec{Name: "max_parallel_launches", Type: cty.Number, Required: false},
+		"target_resource_count":   &hcldec.AttrSpec{Name: "target_resource_count", Type: cty.Number, Required: false},
+	}
+	return s
+}
+
+// FlatFastLaunchTemplateConfig is an auto-generated flat version of FastLaunchTemplateConfig.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatFastLaunchTemplateConfig struct {
+	Region                *string `mapstructure:"region" cty:"region" hcl:"region"`
+	LaunchTemplateID      *string `mapstructure:"template_id" cty:"template_id" hcl:"template_id"`
+	LaunchTemplateName    *string `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
+	LaunchTemplateVersion *int    `mapstructure:"template_version" cty:"template_version" hcl:"template_version"`
+}
+
+// FlatMapstructure returns a new FlatFastLaunchTemplateConfig.
+// FlatFastLaunchTemplateConfig is an auto-generated flat version of FastLaunchTemplateConfig.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*FastLaunchTemplateConfig) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatFastLaunchTemplateConfig)
+}
+
+// HCL2Spec returns the hcl spec of a FastLaunchTemplateConfig.
+// This spec is used by HCL to read the fields of FastLaunchTemplateConfig.
+// The decoded values from this spec will then be applied to a FlatFastLaunchTemplateConfig.
+func (*FlatFastLaunchTemplateConfig) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"region":           &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
+		"template_id":      &hcldec.AttrSpec{Name: "template_id", Type: cty.String, Required: false},
+		"template_name":    &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
+		"template_version": &hcldec.AttrSpec{Name: "template_version", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/ebs/fast_launch_setup_test.go
+++ b/builder/ebs/fast_launch_setup_test.go
@@ -19,6 +19,7 @@ func TestFastLaunchPrepare(t *testing.T) {
 		{
 			"OK - all specified, with template id",
 			FastLaunchConfig{
+				defaultRegion:         "us-east-1",
 				UseFastLaunch:         true,
 				LaunchTemplateID:      "id",
 				LaunchTemplateVersion: 2,
@@ -30,6 +31,7 @@ func TestFastLaunchPrepare(t *testing.T) {
 		{
 			"OK - all specified, with template name",
 			FastLaunchConfig{
+				defaultRegion:         "us-east-1",
 				UseFastLaunch:         true,
 				LaunchTemplateName:    "name",
 				LaunchTemplateVersion: 2,
@@ -41,6 +43,7 @@ func TestFastLaunchPrepare(t *testing.T) {
 		{
 			"Error - max parallel launches < 6",
 			FastLaunchConfig{
+				defaultRegion:       "us-east-1",
 				MaxParallelLaunches: 3,
 			},
 			true,
@@ -48,6 +51,7 @@ func TestFastLaunchPrepare(t *testing.T) {
 		{
 			"Error - target resource count < 0",
 			FastLaunchConfig{
+				defaultRegion:       "us-east-1",
 				TargetResourceCount: -1,
 			},
 			true,
@@ -55,6 +59,7 @@ func TestFastLaunchPrepare(t *testing.T) {
 		{
 			"Error - launch template ID & name specified",
 			FastLaunchConfig{
+				defaultRegion:      "us-east-1",
 				LaunchTemplateID:   "id",
 				LaunchTemplateName: "name",
 			},
@@ -63,6 +68,7 @@ func TestFastLaunchPrepare(t *testing.T) {
 		{
 			"Error - launch template version without name/id",
 			FastLaunchConfig{
+				defaultRegion:         "us-east-1",
 				LaunchTemplateVersion: 2,
 			},
 			true,
@@ -70,6 +76,7 @@ func TestFastLaunchPrepare(t *testing.T) {
 		{
 			"Error - launch template version < 0",
 			FastLaunchConfig{
+				defaultRegion:         "us-east-1",
 				LaunchTemplateVersion: -1,
 			},
 			true,

--- a/docs-partials/builder/ebs/FastLaunchConfig-not-required.mdx
+++ b/docs-partials/builder/ebs/FastLaunchConfig-not-required.mdx
@@ -2,24 +2,43 @@
 
 - `enable_fast_launch` (bool) - Configure fast-launch for Windows AMIs
 
-- `template_id` (string) - The ID of the launch template to use for the fast launch
+- `template_id` (string) - The ID of the launch template to use for fast launch for the main AMI.
   
   This cannot be specified in conjunction with the template name.
   
   If no template is specified, the default launch template will be used,
   as specified in the AWS docs.
+  
+  If you copy the AMI to other regions, this option should not
+  be used, use instead the `fast_launch_template_config` option.
 
-- `template_name` (string) - The name of the launch template to use for fast launch
+- `template_name` (string) - The name of the launch template to use for fast launch for the main AMI.
   
   This cannot be specified in conjunction with the template ID.
   
   If no template is specified, the default launch template will be used,
   as specified in the AWS docs.
+  
+  If you copy the AMI to other regions, this option should not
+  be used, use instead the `fast_launch_template_config` option.
 
-- `template_version` (int) - The version of the launch template to use
+- `template_version` (int) - The version of the launch template to use for fast launch for the main AMI.
   
   If unspecified, and a template is referenced, this will default to
   the latest version available for the template.
+  
+  If you copy the AMI to other regions, this option should not
+  be used, use instead the `fast_launch_template_config` option.
+
+- `region_launch_templates` ([]FastLaunchTemplateConfig) - RegionLaunchTemplates is the list of launch templates per region.
+  
+  This should be specified if you want to use a custom launch
+  template for your fast-launched images, and you are copying
+  the image to other regions.
+  
+  Note: all the regions don't need an entry in this map, but if you
+  don't specify a region's template, a default one will be picked
+  by AWS.
 
 - `max_parallel_launches` (int) - Maximum number of instances to launch for creating pre-provisioned snapshots
   


### PR DESCRIPTION
Prior to this commit, enabling fast-launch was done before copying the AMI to other regions, if the option was selected.

This was problematic, as the pre-provisioned snapshots produced by enabling fast-launch weren't copied over to other regions, so only the source image was supporting fast-launch.

To remedy this problem, we now enable fast-launch after the image is copies to other regions. This fixes the problem, but takes more time to complete the build, since each enabling takes time.

Also, this requirement means that each region may have its own launch template to use for enabling fast-launch, so we introduce a new block in the configuration to specify which region should use which template.
This option does not directly supersede the original `fast_launch_template*` options, but instead assumes that if specified,
will only apply to the region the AMI is built in, and other regions will default if unspecified.

Closes: #445 
