### PR TITLE
docs: fix fast-launch-template-config docs

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -1705,9 +1705,12 @@ https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launc
   template for your fast-launched images, and you are copying
   the image to other regions.
   
-  Note: all the regions don't need an entry in this map, but if you
-  don't specify a region's template, a default one will be picked
-  by AWS.
+  All regions don't need a launch template configuration, but for
+  each that don't have a launch template specified, AWS will pick
+  a default one for that purpose.
+  
+  For information about each entry, refer to the
+  [Fast Launch Template Config](#fast-launch-template-config) documentation.
 
 - `max_parallel_launches` (int) - Maximum number of instances to launch for creating pre-provisioned snapshots
   
@@ -1720,6 +1723,32 @@ https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launc
   march 2023, this defaults to 5 on AWS)
 
 <!-- End of code generated from the comments of the FastLaunchConfig struct in builder/ebs/fast_launch_setup.go; -->
+
+
+#### Fast Launch Template Config
+
+<!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
+
+- `template_id` (string) - The ID of the launch template to use for the fast launch
+  
+  This cannot be specified in conjunction with the template name.
+  
+  If no template is specified, the default launch template will be used,
+  as specified in the AWS docs.
+
+- `template_name` (string) - The name of the launch template to use for fast launch
+  
+  This cannot be specified in conjunction with the template ID.
+  
+  If no template is specified, the default launch template will be used,
+  as specified in the AWS docs.
+
+- `template_version` (int) - The version of the launch template to use
+  
+  If unspecified, and a template is referenced, this will default to
+  the latest version available for the template.
+
+<!-- End of code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; -->
 
 
 ## Accessing the Instance to Debug

--- a/builder/ebs/fast_launch_setup.go
+++ b/builder/ebs/fast_launch_setup.go
@@ -18,7 +18,7 @@ import (
 // copy, and each region may pick their own launch template.
 type FastLaunchTemplateConfig struct {
 	// The region in which to find the launch template to use
-	Region string `mapstructure:"region"`
+	Region string `mapstructure:"region" required:"true"`
 	// The ID of the launch template to use for the fast launch
 	//
 	// This cannot be specified in conjunction with the template name.
@@ -111,9 +111,12 @@ type FastLaunchConfig struct {
 	// template for your fast-launched images, and you are copying
 	// the image to other regions.
 	//
-	// Note: all the regions don't need an entry in this map, but if you
-	// don't specify a region's template, a default one will be picked
-	// by AWS.
+	// All regions don't need a launch template configuration, but for
+	// each that don't have a launch template specified, AWS will pick
+	// a default one for that purpose.
+	//
+	// For information about each entry, refer to the
+	// [Fast Launch Template Config](#fast-launch-template-config) documentation.
 	RegionLaunchTemplates []FastLaunchTemplateConfig `mapstructure:"region_launch_templates"`
 	// Maximum number of instances to launch for creating pre-provisioned snapshots
 	//

--- a/builder/ebs/fast_launch_setup.hcl2spec.go
+++ b/builder/ebs/fast_launch_setup.hcl2spec.go
@@ -45,7 +45,7 @@ func (*FlatFastLaunchConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatFastLaunchTemplateConfig is an auto-generated flat version of FastLaunchTemplateConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatFastLaunchTemplateConfig struct {
-	Region                *string `mapstructure:"region" cty:"region" hcl:"region"`
+	Region                *string `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	LaunchTemplateID      *string `mapstructure:"template_id" cty:"template_id" hcl:"template_id"`
 	LaunchTemplateName    *string `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
 	LaunchTemplateVersion *int    `mapstructure:"template_version" cty:"template_version" hcl:"template_version"`

--- a/docs-partials/builder/ebs/FastLaunchConfig-not-required.mdx
+++ b/docs-partials/builder/ebs/FastLaunchConfig-not-required.mdx
@@ -36,9 +36,12 @@
   template for your fast-launched images, and you are copying
   the image to other regions.
   
-  Note: all the regions don't need an entry in this map, but if you
-  don't specify a region's template, a default one will be picked
-  by AWS.
+  All regions don't need a launch template configuration, but for
+  each that don't have a launch template specified, AWS will pick
+  a default one for that purpose.
+  
+  For information about each entry, refer to the
+  [Fast Launch Template Config](#fast-launch-template-config) documentation.
 
 - `max_parallel_launches` (int) - Maximum number of instances to launch for creating pre-provisioned snapshots
   

--- a/docs-partials/builder/ebs/FastLaunchTemplateConfig-not-required.mdx
+++ b/docs-partials/builder/ebs/FastLaunchTemplateConfig-not-required.mdx
@@ -1,0 +1,22 @@
+<!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
+
+- `template_id` (string) - The ID of the launch template to use for the fast launch
+  
+  This cannot be specified in conjunction with the template name.
+  
+  If no template is specified, the default launch template will be used,
+  as specified in the AWS docs.
+
+- `template_name` (string) - The name of the launch template to use for fast launch
+  
+  This cannot be specified in conjunction with the template ID.
+  
+  If no template is specified, the default launch template will be used,
+  as specified in the AWS docs.
+
+- `template_version` (int) - The version of the launch template to use
+  
+  If unspecified, and a template is referenced, this will default to
+  the latest version available for the template.
+
+<!-- End of code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; -->

--- a/docs-partials/builder/ebs/FastLaunchTemplateConfig.mdx
+++ b/docs-partials/builder/ebs/FastLaunchTemplateConfig.mdx
@@ -1,0 +1,9 @@
+<!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
+
+FastLaunchTemplateConfig is the launch template configuration for a region.
+
+This must be used if the configuration has more than one region specified
+in the template, as each fast-launch enablement step occurs after the
+copy, and each region may pick their own launch template.
+
+<!-- End of code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; -->

--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -288,6 +288,10 @@ Windows](http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/finding-an-ami.ht
 
 @include 'builder/ebs/FastLaunchConfig-not-required.mdx'
 
+#### Fast Launch Template Config
+
+@include 'builder/ebs/FastLaunchTemplateConfig-not-required.mdx'
+
 ## Accessing the Instance to Debug
 
 If you need to access the instance to debug for some reason, run the builder


### PR DESCRIPTION
Introduced with v1.3.0 of the plugin, the fast-launch-template-config was not added to the docs, and since the partials were generated, but not committed, the release docs deployment failed.

This likely hints at the checks for the PR not being sufficient, as they should have pointed it out, but that wasn't the case.

Follow-up to: #451 