### PR TITLE
docs: fix fast-launch-template-config docs

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -1729,6 +1729,15 @@ https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launc
 
 <!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
 
+- `region` (string) - The region in which to find the launch template to use
+
+<!-- End of code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; -->
+
+
+**Optional:**
+
+<!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
+
 - `template_id` (string) - The ID of the launch template to use for the fast launch
   
   This cannot be specified in conjunction with the template name.

--- a/docs-partials/builder/ebs/FastLaunchTemplateConfig-required.mdx
+++ b/docs-partials/builder/ebs/FastLaunchTemplateConfig-required.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
+
+- `region` (string) - The region in which to find the launch template to use
+
+<!-- End of code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; -->

--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -290,6 +290,10 @@ Windows](http://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/finding-an-ami.ht
 
 #### Fast Launch Template Config
 
+@include 'builder/ebs/FastLaunchTemplateConfig-required.mdx'
+
+**Optional:**
+
 @include 'builder/ebs/FastLaunchTemplateConfig-not-required.mdx'
 
 ## Accessing the Instance to Debug


### PR DESCRIPTION
Since the additional required docs for FastLaunchTemplateConfig were not committed at first, the docs aren't complete, and `make generate' returns a diff, making releasing the docs impossible.