### PR TITLE
Enable setting a description for EBS Volume Snapshots

### DIFF
--- a/.web-docs/components/builder/ebsvolume/README.md
+++ b/.web-docs/components/builder/ebsvolume/README.md
@@ -428,6 +428,8 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
 
 - `snapshot_volume` (bool) - Create a Snapshot of this Volume.
 
+- `snapshot_description` (string) - The description for the snapshot.
+
 <!-- End of code generated from the comments of the BlockDevice struct in builder/ebsvolume/block_device.go; -->
 
 

--- a/builder/ebsvolume/block_device.go
+++ b/builder/ebsvolume/block_device.go
@@ -27,6 +27,9 @@ type BlockDevice struct {
 	// Create a Snapshot of this Volume.
 	SnapshotVolume bool `mapstructure:"snapshot_volume" required:"false"`
 
+	// The description for the snapshot.
+	SnapshotDescription string `mapstructure:"snapshot_description" required:"false"`
+
 	awscommon.SnapshotConfig `mapstructure:",squash"`
 }
 

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -162,9 +162,9 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 	}
 
 	for _, configVolumeMapping := range b.config.VolumeMappings {
-		if configVolumeMapping.SnapshotDescription != "" && configVolumeMapping.SnapshotVolume != true {
-			warns = append(warns, "snapshot_description is ignored when "+
-			  "snapshot_volume is not set to true.")
+		if configVolumeMapping.SnapshotDescription != "" && !configVolumeMapping.SnapshotVolume {
+			errs = packersdk.MultiErrorAppend(errs,
+				fmt.Errorf("All `ebs_volumes` blocks setting `snapshot_description` must also set `snapshot_volume`."))
 		}
 	}
 

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -161,6 +161,13 @@ func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {
 			"Packer, inclusion of enable_t2_unlimited will error your builds.")
 	}
 
+	for _, configVolumeMapping := range b.config.VolumeMappings {
+		if configVolumeMapping.SnapshotDescription != "" && configVolumeMapping.SnapshotVolume != true {
+			warns = append(warns, "snapshot_description is ignored when "+
+			  "snapshot_volume is not set to true.")
+		}
+	}
+
 	if errs != nil && len(errs.Errors) > 0 {
 		return nil, warns, errs
 	}

--- a/builder/ebsvolume/builder.hcl2spec.go
+++ b/builder/ebsvolume/builder.hcl2spec.go
@@ -26,6 +26,7 @@ type FlatBlockDevice struct {
 	Tags                map[string]string     `mapstructure:"tags" required:"false" cty:"tags" hcl:"tags"`
 	Tag                 []config.FlatKeyValue `mapstructure:"tag" required:"false" cty:"tag" hcl:"tag"`
 	SnapshotVolume      *bool                 `mapstructure:"snapshot_volume" required:"false" cty:"snapshot_volume" hcl:"snapshot_volume"`
+	SnapshotDescription *string               `mapstructure:"snapshot_description" required:"false" cty:"snapshot_description" hcl:"snapshot_description"`
 	SnapshotTags        map[string]string     `mapstructure:"snapshot_tags" required:"false" cty:"snapshot_tags" hcl:"snapshot_tags"`
 	SnapshotTag         []config.FlatKeyValue `mapstructure:"snapshot_tag" required:"false" cty:"snapshot_tag" hcl:"snapshot_tag"`
 	SnapshotUsers       []string              `mapstructure:"snapshot_users" required:"false" cty:"snapshot_users" hcl:"snapshot_users"`
@@ -58,6 +59,7 @@ func (*FlatBlockDevice) HCL2Spec() map[string]hcldec.Spec {
 		"tags":                  &hcldec.AttrSpec{Name: "tags", Type: cty.Map(cty.String), Required: false},
 		"tag":                   &hcldec.BlockListSpec{TypeName: "tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_volume":       &hcldec.AttrSpec{Name: "snapshot_volume", Type: cty.Bool, Required: false},
+		"snapshot_description":  &hcldec.AttrSpec{Name: "snapshot_description", Type: cty.String, Required: false},
 		"snapshot_tags":         &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.Map(cty.String), Required: false},
 		"snapshot_tag":          &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":        &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},

--- a/builder/ebsvolume/step_snapshot_ebs_volumes.go
+++ b/builder/ebsvolume/step_snapshot_ebs_volumes.go
@@ -59,6 +59,7 @@ func (s *stepSnapshotEBSVolumes) Run(ctx context.Context, state multistep.StateB
 				input := &ec2.CreateSnapshotInput{
 					VolumeId:          aws.String(*instanceBlockDevice.Ebs.VolumeId),
 					TagSpecifications: []*ec2.TagSpecification{tagSpec},
+					Description:       aws.String(configVolumeMapping.SnapshotDescription),
 				}
 
 				//Dont try to set an empty tag spec

--- a/docs-partials/builder/ebsvolume/BlockDevice-not-required.mdx
+++ b/docs-partials/builder/ebsvolume/BlockDevice-not-required.mdx
@@ -11,4 +11,6 @@
 
 - `snapshot_volume` (bool) - Create a Snapshot of this Volume.
 
+- `snapshot_description` (string) - The description for the snapshot.
+
 <!-- End of code generated from the comments of the BlockDevice struct in builder/ebsvolume/block_device.go; -->


### PR DESCRIPTION
This PR adds a new `snapshot_description` field to the block device configuration for the `amazon-ebsvolume` builder. If the companion field `snapshot_volume` is set for the block device, the value of `snapshot_description` will be included as the Description when creating the snapshot.

See [AWS Documentation](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateSnapshot.html#API_CreateSnapshot_RequestParameters) for the Description request parameter.

Closes #470

