### PR TITLE
feat: allow customizing spot allocation strategy

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -814,6 +814,12 @@ JSON example:
     criteria provided in `source_ami_filter`; this pins the AMI returned by the
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
+- `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
+  	 The strategy that determines how to allocate the target Spot Instance capacity
+  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
+  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max
   price of spot_price and the allocation strategy of "lowest price".

--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -815,10 +815,10 @@ JSON example:
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
 - `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
-  	 The strategy that determines how to allocate the target Spot Instance capacity
-  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
-  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
-  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+  The strategy that determines how to allocate the target Spot Instance capacity
+  across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  If this option is not set, Packer will use default option provided by the SDK (currently `lowest-price`).
+  For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
 
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -827,6 +827,12 @@ JSON example:
     criteria provided in `source_ami_filter`; this pins the AMI returned by the
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
+- `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
+  	 The strategy that determines how to allocate the target Spot Instance capacity
+  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
+  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max
   price of spot_price and the allocation strategy of "lowest price".

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -828,10 +828,10 @@ JSON example:
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
 - `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
-  	 The strategy that determines how to allocate the target Spot Instance capacity
-  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
-  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
-  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+  The strategy that determines how to allocate the target Spot Instance capacity
+  across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  If this option is not set, Packer will use default option provided by the SDK (currently `lowest-price`).
+  For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
 
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max

--- a/.web-docs/components/builder/ebsvolume/README.md
+++ b/.web-docs/components/builder/ebsvolume/README.md
@@ -762,10 +762,10 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
 - `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
-  	 The strategy that determines how to allocate the target Spot Instance capacity
-  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
-  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
-  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+  The strategy that determines how to allocate the target Spot Instance capacity
+  across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  If this option is not set, Packer will use default option provided by the SDK (currently `lowest-price`).
+  For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
 
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max

--- a/.web-docs/components/builder/ebsvolume/README.md
+++ b/.web-docs/components/builder/ebsvolume/README.md
@@ -761,6 +761,12 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
     criteria provided in `source_ami_filter`; this pins the AMI returned by the
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
+- `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
+  	 The strategy that determines how to allocate the target Spot Instance capacity
+  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
+  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max
   price of spot_price and the allocation strategy of "lowest price".

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -811,10 +811,10 @@ JSON example:
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
 - `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
-  	 The strategy that determines how to allocate the target Spot Instance capacity
-  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
-  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
-  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+  The strategy that determines how to allocate the target Spot Instance capacity
+  across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  If this option is not set, Packer will use default option provided by the SDK (currently `lowest-price`).
+  For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
 
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -810,6 +810,12 @@ JSON example:
     criteria provided in `source_ami_filter`; this pins the AMI returned by the
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
+- `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
+  	 The strategy that determines how to allocate the target Spot Instance capacity
+  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
+  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max
   price of spot_price and the allocation strategy of "lowest price".

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -843,11 +843,10 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		}
 	}
 
-	if c.SpotAllocationStrategy != "" {
-		if !slices.Contains(ec2.SpotAllocationStrategy_Values(), c.SpotAllocationStrategy) {
-			errs = append(errs, fmt.Errorf(
-				"Unknown spot_allocation_strategy: %s", c.SpotAllocationStrategy))
-		}
+	if c.SpotAllocationStrategy != "" && !slices.Contains(ec2.SpotAllocationStrategy_Values(),
+		c.SpotAllocationStrategy) {
+		errs = append(errs, fmt.Errorf(
+			"Unknown spot_allocation_strategy: %s", c.SpotAllocationStrategy))
 	}
 
 	if c.UserData != "" && c.UserDataFile != "" {

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -404,10 +404,10 @@ type RunConfig struct {
 	//   filter, but will cause Packer to fail if the `source_ami` does not exist.
 	SourceAmiFilter AmiFilterOptions `mapstructure:"source_ami_filter" required:"false"`
 	// One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
-	// 	 The strategy that determines how to allocate the target Spot Instance capacity
-	// 	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
-	// 	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
-	// 	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+	// The strategy that determines how to allocate the target Spot Instance capacity
+	// across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+	// If this option is not set, Packer will use default option provided by the SDK (currently `lowest-price`).
+	// For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
 	SpotAllocationStrategy string `mapstructure:"spot_allocation_strategy" required:"false"`
 	// a list of acceptable instance
 	// types to run your build on. We will request a spot instance using the max

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -11,9 +11,11 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
@@ -838,6 +840,13 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		if c.SpotPrice == "" || c.SpotPrice == "0" {
 			errs = append(errs, fmt.Errorf(
 				"spot_tags should not be set when not requesting a spot instance"))
+		}
+	}
+
+	if c.SpotAllocationStrategy != "" {
+		if !slices.Contains(ec2.SpotAllocationStrategy_Values(), c.SpotAllocationStrategy) {
+			errs = append(errs, fmt.Errorf(
+				"Unknown spot_allocation_strategy: %s", c.SpotAllocationStrategy))
 		}
 	}
 

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -401,6 +401,12 @@ type RunConfig struct {
 	//   criteria provided in `source_ami_filter`; this pins the AMI returned by the
 	//   filter, but will cause Packer to fail if the `source_ami` does not exist.
 	SourceAmiFilter AmiFilterOptions `mapstructure:"source_ami_filter" required:"false"`
+	// One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
+	// 	 The strategy that determines how to allocate the target Spot Instance capacity
+	// 	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+	// 	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
+	// 	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+	SpotAllocationStrategy string `mapstructure:"spot_allocation_strategy" required:"false"`
 	// a list of acceptable instance
 	// types to run your build on. We will request a spot instance using the max
 	// price of spot_price and the allocation strategy of "lowest price".

--- a/builder/common/run_config_test.go
+++ b/builder/common/run_config_test.go
@@ -582,3 +582,13 @@ func TestRunConfigPrepare_WithCapacityReservations(t *testing.T) {
 		})
 	}
 }
+
+func TestRunConfigPrepare_EnableSpotInstanceBadSpotAllocationStrategy(t *testing.T) {
+	c := testConfig()
+	// There should be some error when Spot Allocation Strategy is invalid.
+	c.SpotAllocationStrategy = "very-expensive-one"
+	err := c.Prepare(nil)
+	if len(err) != 1 {
+		t.Fatalf("Should error if spot_allocation_strategy is invalid.")
+	}
+}

--- a/builder/common/run_config_test.go
+++ b/builder/common/run_config_test.go
@@ -589,6 +589,6 @@ func TestRunConfigPrepare_EnableSpotInstanceBadSpotAllocationStrategy(t *testing
 	c.SpotAllocationStrategy = "very-expensive-one"
 	err := c.Prepare(nil)
 	if len(err) != 1 {
-		t.Fatalf("Should error if spot_allocation_strategy is invalid.")
+		t.Fatalf("Should error if spot_allocation_strategy is invalid. Expected 1 error, got %d", len(err))
 	}
 }

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"slices"
 	"strings"
 	"time"
 
@@ -386,7 +385,7 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		Type: aws.String("instant"),
 	}
 
-	if slices.Contains(ec2.SpotAllocationStrategy_Values(), s.SpotAllocationStrategy) {
+	if s.SpotAllocationStrategy != "" {
 		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{
 			AllocationStrategy: aws.String(s.SpotAllocationStrategy),
 		}

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -48,6 +49,7 @@ type StepRunSpotInstance struct {
 	InstanceType                      string
 	Region                            string
 	SourceAMI                         string
+	SpotAllocationStrategy            string
 	SpotPrice                         string
 	SpotTags                          map[string]string
 	SpotInstanceTypes                 []string
@@ -382,6 +384,12 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 			DefaultTargetCapacityType: aws.String("spot"),
 		},
 		Type: aws.String("instant"),
+	}
+
+	if slices.Contains(ec2.SpotAllocationStrategy_Values(), s.SpotAllocationStrategy) {
+		createFleetInput.SpotOptions = &ec2.SpotOptionsRequest{
+			AllocationStrategy: aws.String(s.SpotAllocationStrategy),
+		}
 	}
 
 	fleetTags, err := TagMap(s.FleetTags).EC2Tags(s.Ctx, s.Region, state)

--- a/builder/common/step_run_spot_instance_test.go
+++ b/builder/common/step_run_spot_instance_test.go
@@ -54,6 +54,7 @@ func getBasicStep() *StepRunSpotInstance {
 		Region:                            "us-east-1",
 		SourceAMI:                         "",
 		SpotPrice:                         "auto",
+		SpotAllocationStrategy:            "price-capacity-optimized",
 		SpotTags:                          nil,
 		Tags:                              map[string]string{},
 		VolumeTags:                        nil,
@@ -250,6 +251,7 @@ func TestRun(t *testing.T) {
 	spotRequestId := aws.String("spot-id")
 	volumeId := aws.String("volume-id")
 	launchTemplateId := aws.String("launchTemplateId")
+	spotAllocationStrategy := aws.String("price-capacity-optimized")
 	ec2Mock := defaultEc2Mock(instanceId, spotRequestId, volumeId, launchTemplateId)
 
 	uiMock := packersdk.TestUi(t)
@@ -317,6 +319,9 @@ func TestRun(t *testing.T) {
 	}
 	if *ec2Mock.CreateFleetParams[0].LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName != *launchTemplateName {
 		t.Fatalf("launchTemplateName should match in createLaunchTemplate and createFleet requests")
+	}
+	if *ec2Mock.CreateFleetParams[0].SpotOptions.AllocationStrategy != *spotAllocationStrategy {
+		t.Fatalf("AllocationStrategy in CreateFleet request should match with spotAllocationStrategy param.")
 	}
 
 	fleetNameTag := ec2Mock.CreateFleetParams[0].TagSpecifications[0].Tags[0]

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -244,7 +244,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SpotTags:                          b.config.SpotTags,
 			Tags:                              b.config.RunTags,
 			SpotInstanceTypes:                 b.config.SpotInstanceTypes,
-			SpotAllocationStrategy:            b.config.RunConfig.SpotAllocationStrategy,
+			SpotAllocationStrategy:            b.config.SpotAllocationStrategy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -244,6 +244,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SpotTags:                          b.config.SpotTags,
 			Tags:                              b.config.RunTags,
 			SpotInstanceTypes:                 b.config.SpotInstanceTypes,
+			SpotAllocationStrategy:            b.config.RunConfig.SpotAllocationStrategy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,
 			VolumeTags:                        b.config.VolumeRunTags,

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -89,6 +89,7 @@ type FlatConfig struct {
 	SecurityGroupIds                          []string                                    `mapstructure:"security_group_ids" required:"false" cty:"security_group_ids" hcl:"security_group_ids"`
 	SourceAmi                                 *string                                     `mapstructure:"source_ami" required:"true" cty:"source_ami" hcl:"source_ami"`
 	SourceAmiFilter                           *common.FlatAmiFilterOptions                `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter" hcl:"source_ami_filter"`
+	SpotAllocationStrategy                    *string                                     `mapstructure:"spot_allocation_strategy" required:"false" cty:"spot_allocation_strategy" hcl:"spot_allocation_strategy"`
 	SpotInstanceTypes                         []string                                    `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types" hcl:"spot_instance_types"`
 	SpotPrice                                 *string                                     `mapstructure:"spot_price" required:"false" cty:"spot_price" hcl:"spot_price"`
 	SpotPriceAutoProduct                      *string                                     `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product" hcl:"spot_price_auto_product"`
@@ -227,7 +228,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"skip_save_build_region":          &hcldec.AttrSpec{Name: "skip_save_build_region", Type: cty.Bool, Required: false},
 		"snapshot_copy_duration_minutes":  &hcldec.AttrSpec{Name: "snapshot_copy_duration_minutes", Type: cty.Number, Required: false},
 		"imds_support":                    &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
-		"deprecate_at":                    &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"snapshot_tags":                   &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.Map(cty.String), Required: false},
 		"snapshot_tag":                    &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":                  &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},
@@ -258,6 +258,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"security_group_ids":                    &hcldec.AttrSpec{Name: "security_group_ids", Type: cty.List(cty.String), Required: false},
 		"source_ami":                            &hcldec.AttrSpec{Name: "source_ami", Type: cty.String, Required: false},
 		"source_ami_filter":                     &hcldec.BlockSpec{TypeName: "source_ami_filter", Nested: hcldec.ObjectSpec((*common.FlatAmiFilterOptions)(nil).HCL2Spec())},
+		"spot_allocation_strategy":              &hcldec.AttrSpec{Name: "spot_allocation_strategy", Type: cty.String, Required: false},
 		"spot_instance_types":                   &hcldec.AttrSpec{Name: "spot_instance_types", Type: cty.List(cty.String), Required: false},
 		"spot_price":                            &hcldec.AttrSpec{Name: "spot_price", Type: cty.String, Required: false},
 		"spot_price_auto_product":               &hcldec.AttrSpec{Name: "spot_price_auto_product", Type: cty.String, Required: false},
@@ -335,6 +336,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"run_volume_tags":              &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},
 		"run_volume_tag":               &hcldec.BlockListSpec{TypeName: "run_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatNameValue)(nil).HCL2Spec())},
 		"no_ephemeral":                 &hcldec.AttrSpec{Name: "no_ephemeral", Type: cty.Bool, Required: false},
+		"deprecate_at":                 &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"fast_launch":                  &hcldec.BlockSpec{TypeName: "fast_launch", Nested: hcldec.ObjectSpec((*FlatFastLaunchConfig)(nil).HCL2Spec())},
 	}
 	return s

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -228,6 +228,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"skip_save_build_region":          &hcldec.AttrSpec{Name: "skip_save_build_region", Type: cty.Bool, Required: false},
 		"snapshot_copy_duration_minutes":  &hcldec.AttrSpec{Name: "snapshot_copy_duration_minutes", Type: cty.Number, Required: false},
 		"imds_support":                    &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"deprecate_at":                    &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"snapshot_tags":                   &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.Map(cty.String), Required: false},
 		"snapshot_tag":                    &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":                  &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},
@@ -336,7 +337,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"run_volume_tags":              &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},
 		"run_volume_tag":               &hcldec.BlockListSpec{TypeName: "run_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatNameValue)(nil).HCL2Spec())},
 		"no_ephemeral":                 &hcldec.AttrSpec{Name: "no_ephemeral", Type: cty.Bool, Required: false},
-		"deprecate_at":                 &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"fast_launch":                  &hcldec.BlockSpec{TypeName: "fast_launch", Nested: hcldec.ObjectSpec((*FlatFastLaunchConfig)(nil).HCL2Spec())},
 	}
 	return s

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -278,6 +278,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Region:                            *ec2conn.Config.Region,
 			SourceAMI:                         b.config.SourceAmi,
 			SpotPrice:                         b.config.SpotPrice,
+			SpotAllocationStrategy:            b.config.SpotAllocationStrategy,
 			SpotInstanceTypes:                 b.config.SpotInstanceTypes,
 			SpotTags:                          b.config.SpotTags,
 			Tags:                              b.config.RunTags,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -106,6 +106,7 @@ type FlatConfig struct {
 	SecurityGroupIds                          []string                                    `mapstructure:"security_group_ids" required:"false" cty:"security_group_ids" hcl:"security_group_ids"`
 	SourceAmi                                 *string                                     `mapstructure:"source_ami" required:"true" cty:"source_ami" hcl:"source_ami"`
 	SourceAmiFilter                           *common.FlatAmiFilterOptions                `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter" hcl:"source_ami_filter"`
+	SpotAllocationStrategy                    *string                                     `mapstructure:"spot_allocation_strategy" required:"false" cty:"spot_allocation_strategy" hcl:"spot_allocation_strategy"`
 	SpotInstanceTypes                         []string                                    `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types" hcl:"spot_instance_types"`
 	SpotPrice                                 *string                                     `mapstructure:"spot_price" required:"false" cty:"spot_price" hcl:"spot_price"`
 	SpotPriceAutoProduct                      *string                                     `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product" hcl:"spot_price_auto_product"`
@@ -279,6 +280,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"security_group_ids":                    &hcldec.AttrSpec{Name: "security_group_ids", Type: cty.List(cty.String), Required: false},
 		"source_ami":                            &hcldec.AttrSpec{Name: "source_ami", Type: cty.String, Required: false},
 		"source_ami_filter":                     &hcldec.BlockSpec{TypeName: "source_ami_filter", Nested: hcldec.ObjectSpec((*common.FlatAmiFilterOptions)(nil).HCL2Spec())},
+		"spot_allocation_strategy":              &hcldec.AttrSpec{Name: "spot_allocation_strategy", Type: cty.String, Required: false},
 		"spot_instance_types":                   &hcldec.AttrSpec{Name: "spot_instance_types", Type: cty.List(cty.String), Required: false},
 		"spot_price":                            &hcldec.AttrSpec{Name: "spot_price", Type: cty.String, Required: false},
 		"spot_price_auto_product":               &hcldec.AttrSpec{Name: "spot_price_auto_product", Type: cty.String, Required: false},

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -11,6 +11,7 @@ package ebsvolume
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -200,6 +201,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	var instanceStep multistep.Step
 
 	if b.config.IsSpotInstance() {
+		log.Printf("%s", "Using Spot Instance to create EBS volumes")
 		instanceStep = &awscommon.StepRunSpotInstance{
 			PollingConfig:                     b.config.PollingConfig,
 			AssociatePublicIpAddress:          b.config.AssociatePublicIpAddress,
@@ -222,6 +224,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Region:                            *ec2conn.Config.Region,
 			SourceAMI:                         b.config.SourceAmi,
 			SpotInstanceTypes:                 b.config.SpotInstanceTypes,
+			SpotAllocationStrategy:            b.config.SpotAllocationStrategy,
 			SpotPrice:                         b.config.SpotPrice,
 			SpotTags:                          b.config.SpotTags,
 			Tags:                              b.config.RunTags,

--- a/builder/ebsvolume/builder.hcl2spec.go
+++ b/builder/ebsvolume/builder.hcl2spec.go
@@ -120,6 +120,7 @@ type FlatConfig struct {
 	SecurityGroupIds                          []string                               `mapstructure:"security_group_ids" required:"false" cty:"security_group_ids" hcl:"security_group_ids"`
 	SourceAmi                                 *string                                `mapstructure:"source_ami" required:"true" cty:"source_ami" hcl:"source_ami"`
 	SourceAmiFilter                           *common.FlatAmiFilterOptions           `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter" hcl:"source_ami_filter"`
+	SpotAllocationStrategy                    *string                                `mapstructure:"spot_allocation_strategy" required:"false" cty:"spot_allocation_strategy" hcl:"spot_allocation_strategy"`
 	SpotInstanceTypes                         []string                               `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types" hcl:"spot_instance_types"`
 	SpotPrice                                 *string                                `mapstructure:"spot_price" required:"false" cty:"spot_price" hcl:"spot_price"`
 	SpotPriceAutoProduct                      *string                                `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product" hcl:"spot_price_auto_product"`
@@ -258,6 +259,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"security_group_ids":                    &hcldec.AttrSpec{Name: "security_group_ids", Type: cty.List(cty.String), Required: false},
 		"source_ami":                            &hcldec.AttrSpec{Name: "source_ami", Type: cty.String, Required: false},
 		"source_ami_filter":                     &hcldec.BlockSpec{TypeName: "source_ami_filter", Nested: hcldec.ObjectSpec((*common.FlatAmiFilterOptions)(nil).HCL2Spec())},
+		"spot_allocation_strategy":              &hcldec.AttrSpec{Name: "spot_allocation_strategy", Type: cty.String, Required: false},
 		"spot_instance_types":                   &hcldec.AttrSpec{Name: "spot_instance_types", Type: cty.List(cty.String), Required: false},
 		"spot_price":                            &hcldec.AttrSpec{Name: "spot_price", Type: cty.String, Required: false},
 		"spot_price_auto_product":               &hcldec.AttrSpec{Name: "spot_price_auto_product", Type: cty.String, Required: false},

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -294,6 +294,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SourceAMI:                b.config.SourceAmi,
 			SpotPrice:                b.config.SpotPrice,
 			SpotInstanceTypes:        b.config.SpotInstanceTypes,
+			SpotAllocationStrategy:   b.config.SpotAllocationStrategy,
 			Tags:                     b.config.RunTags,
 			SpotTags:                 b.config.SpotTags,
 			UserData:                 b.config.UserData,

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -89,6 +89,7 @@ type FlatConfig struct {
 	SecurityGroupIds                          []string                                    `mapstructure:"security_group_ids" required:"false" cty:"security_group_ids" hcl:"security_group_ids"`
 	SourceAmi                                 *string                                     `mapstructure:"source_ami" required:"true" cty:"source_ami" hcl:"source_ami"`
 	SourceAmiFilter                           *common.FlatAmiFilterOptions                `mapstructure:"source_ami_filter" required:"false" cty:"source_ami_filter" hcl:"source_ami_filter"`
+	SpotAllocationStrategy                    *string                                     `mapstructure:"spot_allocation_strategy" required:"false" cty:"spot_allocation_strategy" hcl:"spot_allocation_strategy"`
 	SpotInstanceTypes                         []string                                    `mapstructure:"spot_instance_types" required:"false" cty:"spot_instance_types" hcl:"spot_instance_types"`
 	SpotPrice                                 *string                                     `mapstructure:"spot_price" required:"false" cty:"spot_price" hcl:"spot_price"`
 	SpotPriceAutoProduct                      *string                                     `mapstructure:"spot_price_auto_product" required:"false" undocumented:"true" cty:"spot_price_auto_product" hcl:"spot_price_auto_product"`
@@ -262,6 +263,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"security_group_ids":                    &hcldec.AttrSpec{Name: "security_group_ids", Type: cty.List(cty.String), Required: false},
 		"source_ami":                            &hcldec.AttrSpec{Name: "source_ami", Type: cty.String, Required: false},
 		"source_ami_filter":                     &hcldec.BlockSpec{TypeName: "source_ami_filter", Nested: hcldec.ObjectSpec((*common.FlatAmiFilterOptions)(nil).HCL2Spec())},
+		"spot_allocation_strategy":              &hcldec.AttrSpec{Name: "spot_allocation_strategy", Type: cty.String, Required: false},
 		"spot_instance_types":                   &hcldec.AttrSpec{Name: "spot_instance_types", Type: cty.List(cty.String), Required: false},
 		"spot_price":                            &hcldec.AttrSpec{Name: "spot_price", Type: cty.String, Required: false},
 		"spot_price_auto_product":               &hcldec.AttrSpec{Name: "spot_price_auto_product", Type: cty.String, Required: false},

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -278,10 +278,10 @@
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
 - `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
-  	 The strategy that determines how to allocate the target Spot Instance capacity
-  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
-  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
-  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+  The strategy that determines how to allocate the target Spot Instance capacity
+  across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  If this option is not set, Packer will use default option provided by the SDK (currently `lowest-price`).
+  For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
 
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -277,6 +277,12 @@
     criteria provided in `source_ami_filter`; this pins the AMI returned by the
     filter, but will cause Packer to fail if the `source_ami` does not exist.
 
+- `spot_allocation_strategy` (string) - One of  `price-capacity-optimized`, `capacity-optimized`, `diversified` or `lowest-price`.
+  	 The strategy that determines how to allocate the target Spot Instance capacity
+  	 across the Spot Instance pools specified by the EC2 Fleet launch configuration.
+  	 If this option is not set/set to invalid value, Packer will use default option provided by the SDK (currently `lowest-price`).
+  	 For more information, see [Amazon EC2 User Guide] (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)
+
 - `spot_instance_types` ([]string) - a list of acceptable instance
   types to run your build on. We will request a spot instance using the max
   price of spot_price and the allocation strategy of "lowest price".


### PR DESCRIPTION
Allow user to pass Spot Allocation Strategy into Fleet Request. 

Closes #427 