### PR TITLE
common: move deprecation_time to AMIConfig

### DIFF
--- a/.web-docs/components/builder/chroot/README.md
+++ b/.web-docs/components/builder/chroot/README.md
@@ -387,6 +387,10 @@ builders.
   [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
   for more information. Defaults to legacy.
 
+- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
+  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
+  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
+
 <!-- End of code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; -->
 
 

--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -77,10 +77,6 @@ necessary for this build to succeed and can be found further down the page.
   make sure you don't set this for *nix guests; behavior may be
   unpredictable.
 
-- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
-  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
-  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
-
 - `fast_launch` (FastLaunchConfig) - The configuration for fast launch support.
   
   Fast launch is only relevant for Windows AMIs, and should not be used
@@ -241,6 +237,10 @@ necessary for this build to succeed and can be found further down the page.
   Valid options are unset (legacy) and `v2.0`. See the documentation on
   [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
   for more information. Defaults to legacy.
+
+- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
+  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
+  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
 
 <!-- End of code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; -->
 

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -249,6 +249,10 @@ necessary for this build to succeed and can be found further down the page.
   [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
   for more information. Defaults to legacy.
 
+- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
+  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
+  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
+
 <!-- End of code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; -->
 
 

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -261,6 +261,10 @@ necessary for this build to succeed and can be found further down the page.
   [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
   for more information. Defaults to legacy.
 
+- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
+  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
+  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
+
 <!-- End of code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; -->
 
 

--- a/builder/chroot/builder.go
+++ b/builder/chroot/builder.go
@@ -531,6 +531,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Name:              b.config.AMIName,
 			OriginalRegion:    *ec2conn.Config.Region,
 		},
+		&awscommon.StepEnableDeprecation{
+			AccessConfig:    &b.config.AccessConfig,
+			DeprecationTime: b.config.DeprecationTime,
+		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,
 			Users:          b.config.AMIUsers,

--- a/builder/chroot/builder.hcl2spec.go
+++ b/builder/chroot/builder.hcl2spec.go
@@ -41,6 +41,7 @@ type FlatConfig struct {
 	AMIRegionKMSKeyIDs      map[string]string                 `mapstructure:"region_kms_key_ids" required:"false" cty:"region_kms_key_ids" hcl:"region_kms_key_ids"`
 	AMISkipBuildRegion      *bool                             `mapstructure:"skip_save_build_region" cty:"skip_save_build_region" hcl:"skip_save_build_region"`
 	AMIIMDSSupport          *string                           `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
+	DeprecationTime         *string                           `mapstructure:"deprecate_at" cty:"deprecate_at" hcl:"deprecate_at"`
 	SnapshotTags            map[string]string                 `mapstructure:"snapshot_tags" required:"false" cty:"snapshot_tags" hcl:"snapshot_tags"`
 	SnapshotTag             []config.FlatKeyValue             `mapstructure:"snapshot_tag" required:"false" cty:"snapshot_tag" hcl:"snapshot_tag"`
 	SnapshotUsers           []string                          `mapstructure:"snapshot_users" required:"false" cty:"snapshot_users" hcl:"snapshot_users"`
@@ -129,6 +130,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"region_kms_key_ids":            &hcldec.AttrSpec{Name: "region_kms_key_ids", Type: cty.Map(cty.String), Required: false},
 		"skip_save_build_region":        &hcldec.AttrSpec{Name: "skip_save_build_region", Type: cty.Bool, Required: false},
 		"imds_support":                  &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"deprecate_at":                  &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"snapshot_tags":                 &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.Map(cty.String), Required: false},
 		"snapshot_tag":                  &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":                &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},

--- a/builder/common/step_enable_deprecation.go
+++ b/builder/common/step_enable_deprecation.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package ebs
+package common
 
 import (
 	"context"
@@ -9,18 +9,17 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/hashicorp/packer-plugin-amazon/builder/common"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-type stepEnableDeprecation struct {
-	AccessConfig       *common.AccessConfig
+type StepEnableDeprecation struct {
+	AccessConfig       *AccessConfig
 	DeprecationTime    string
 	AMISkipCreateImage bool
 }
 
-func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepEnableDeprecation) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packersdk.Ui)
 	if s.AMISkipCreateImage || s.DeprecationTime == "" {
 		ui.Say("Skipping Enable AMI deprecation...")
@@ -39,7 +38,7 @@ func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBa
 	for region, ami := range amis {
 		ui.Say(fmt.Sprintf("Enabling deprecation on AMI (%s) in region %q ...", ami, region))
 
-		conn, err := common.GetRegionConn(s.AccessConfig, region)
+		conn, err := GetRegionConn(s.AccessConfig, region)
 		if err != nil {
 			err := fmt.Errorf("failed to connect to region %s: %s", region, err)
 			state.Put("error", err.Error())
@@ -60,6 +59,6 @@ func (s *stepEnableDeprecation) Run(ctx context.Context, state multistep.StateBa
 	}
 	return multistep.ActionContinue
 }
-func (s *stepEnableDeprecation) Cleanup(state multistep.StateBag) {
+func (s *StepEnableDeprecation) Cleanup(state multistep.StateBag) {
 	// No cleanup...
 }

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -57,6 +57,7 @@ type FlatConfig struct {
 	AMIRegionKMSKeyIDs                        map[string]string                      `mapstructure:"region_kms_key_ids" required:"false" cty:"region_kms_key_ids" hcl:"region_kms_key_ids"`
 	AMISkipBuildRegion                        *bool                                  `mapstructure:"skip_save_build_region" cty:"skip_save_build_region" hcl:"skip_save_build_region"`
 	AMIIMDSSupport                            *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
+	DeprecationTime                           *string                                `mapstructure:"deprecate_at" cty:"deprecate_at" hcl:"deprecate_at"`
 	SnapshotTags                              map[string]string                      `mapstructure:"snapshot_tags" required:"false" cty:"snapshot_tags" hcl:"snapshot_tags"`
 	SnapshotTag                               []config.FlatKeyValue                  `mapstructure:"snapshot_tag" required:"false" cty:"snapshot_tag" hcl:"snapshot_tag"`
 	SnapshotUsers                             []string                               `mapstructure:"snapshot_users" required:"false" cty:"snapshot_users" hcl:"snapshot_users"`
@@ -162,7 +163,6 @@ type FlatConfig struct {
 	VolumeRunTags                             map[string]string                      `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
 	VolumeRunTag                              []config.FlatNameValue                 `mapstructure:"run_volume_tag" required:"false" cty:"run_volume_tag" hcl:"run_volume_tag"`
 	NoEphemeral                               *bool                                  `mapstructure:"no_ephemeral" required:"false" cty:"no_ephemeral" hcl:"no_ephemeral"`
-	DeprecationTime                           *string                                `mapstructure:"deprecate_at" cty:"deprecate_at" hcl:"deprecate_at"`
 	FastLaunch                                *FlatFastLaunchConfig                  `mapstructure:"fast_launch" required:"false" cty:"fast_launch" hcl:"fast_launch"`
 }
 
@@ -223,6 +223,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"region_kms_key_ids":              &hcldec.AttrSpec{Name: "region_kms_key_ids", Type: cty.Map(cty.String), Required: false},
 		"skip_save_build_region":          &hcldec.AttrSpec{Name: "skip_save_build_region", Type: cty.Bool, Required: false},
 		"imds_support":                    &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"deprecate_at":                    &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"snapshot_tags":                   &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.Map(cty.String), Required: false},
 		"snapshot_tag":                    &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":                  &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},
@@ -328,7 +329,6 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"run_volume_tags":              &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},
 		"run_volume_tag":               &hcldec.BlockListSpec{TypeName: "run_volume_tag", Nested: hcldec.ObjectSpec((*config.FlatNameValue)(nil).HCL2Spec())},
 		"no_ephemeral":                 &hcldec.AttrSpec{Name: "no_ephemeral", Type: cty.Bool, Required: false},
-		"deprecate_at":                 &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"fast_launch":                  &hcldec.BlockSpec{TypeName: "fast_launch", Nested: hcldec.ObjectSpec((*FlatFastLaunchConfig)(nil).HCL2Spec())},
 	}
 	return s

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -494,6 +494,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			OriginalRegion:     *ec2conn.Config.Region,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
 		},
+		&awscommon.StepEnableDeprecation{
+			AccessConfig:    &b.config.AccessConfig,
+			DeprecationTime: b.config.DeprecationTime,
+		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,
 			Users:          b.config.AMIUsers,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -197,6 +197,7 @@ type FlatConfig struct {
 	AMIRegionKMSKeyIDs                        map[string]string                      `mapstructure:"region_kms_key_ids" required:"false" cty:"region_kms_key_ids" hcl:"region_kms_key_ids"`
 	AMISkipBuildRegion                        *bool                                  `mapstructure:"skip_save_build_region" cty:"skip_save_build_region" hcl:"skip_save_build_region"`
 	AMIIMDSSupport                            *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
+	DeprecationTime                           *string                                `mapstructure:"deprecate_at" cty:"deprecate_at" hcl:"deprecate_at"`
 	SnapshotTags                              map[string]string                      `mapstructure:"snapshot_tags" required:"false" cty:"snapshot_tags" hcl:"snapshot_tags"`
 	SnapshotTag                               []config.FlatKeyValue                  `mapstructure:"snapshot_tag" required:"false" cty:"snapshot_tag" hcl:"snapshot_tag"`
 	SnapshotUsers                             []string                               `mapstructure:"snapshot_users" required:"false" cty:"snapshot_users" hcl:"snapshot_users"`
@@ -365,6 +366,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"region_kms_key_ids":           &hcldec.AttrSpec{Name: "region_kms_key_ids", Type: cty.Map(cty.String), Required: false},
 		"skip_save_build_region":       &hcldec.AttrSpec{Name: "skip_save_build_region", Type: cty.Bool, Required: false},
 		"imds_support":                 &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"deprecate_at":                 &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"snapshot_tags":                &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.Map(cty.String), Required: false},
 		"snapshot_tag":                 &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":               &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -456,6 +456,10 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Name:              b.config.AMIName,
 			OriginalRegion:    *ec2conn.Config.Region,
 		},
+		&awscommon.StepEnableDeprecation{
+			AccessConfig:    &b.config.AccessConfig,
+			DeprecationTime: b.config.DeprecationTime,
+		},
 		&awscommon.StepModifyAMIAttributes{
 			Description:    b.config.AMIDescription,
 			Users:          b.config.AMIUsers,

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -57,6 +57,7 @@ type FlatConfig struct {
 	AMIRegionKMSKeyIDs                        map[string]string                      `mapstructure:"region_kms_key_ids" required:"false" cty:"region_kms_key_ids" hcl:"region_kms_key_ids"`
 	AMISkipBuildRegion                        *bool                                  `mapstructure:"skip_save_build_region" cty:"skip_save_build_region" hcl:"skip_save_build_region"`
 	AMIIMDSSupport                            *string                                `mapstructure:"imds_support" required:"false" cty:"imds_support" hcl:"imds_support"`
+	DeprecationTime                           *string                                `mapstructure:"deprecate_at" cty:"deprecate_at" hcl:"deprecate_at"`
 	SnapshotTags                              map[string]string                      `mapstructure:"snapshot_tags" required:"false" cty:"snapshot_tags" hcl:"snapshot_tags"`
 	SnapshotTag                               []config.FlatKeyValue                  `mapstructure:"snapshot_tag" required:"false" cty:"snapshot_tag" hcl:"snapshot_tag"`
 	SnapshotUsers                             []string                               `mapstructure:"snapshot_users" required:"false" cty:"snapshot_users" hcl:"snapshot_users"`
@@ -227,6 +228,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"region_kms_key_ids":              &hcldec.AttrSpec{Name: "region_kms_key_ids", Type: cty.Map(cty.String), Required: false},
 		"skip_save_build_region":          &hcldec.AttrSpec{Name: "skip_save_build_region", Type: cty.Bool, Required: false},
 		"imds_support":                    &hcldec.AttrSpec{Name: "imds_support", Type: cty.String, Required: false},
+		"deprecate_at":                    &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
 		"snapshot_tags":                   &hcldec.AttrSpec{Name: "snapshot_tags", Type: cty.Map(cty.String), Required: false},
 		"snapshot_tag":                    &hcldec.BlockListSpec{TypeName: "snapshot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"snapshot_users":                  &hcldec.AttrSpec{Name: "snapshot_users", Type: cty.List(cty.String), Required: false},

--- a/docs-partials/builder/common/AMIConfig-not-required.mdx
+++ b/docs-partials/builder/common/AMIConfig-not-required.mdx
@@ -133,4 +133,8 @@
   [IMDS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
   for more information. Defaults to legacy.
 
+- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
+  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
+  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
+
 <!-- End of code generated from the comments of the AMIConfig struct in builder/common/ami_config.go; -->

--- a/docs-partials/builder/ebs/Config-not-required.mdx
+++ b/docs-partials/builder/ebs/Config-not-required.mdx
@@ -40,10 +40,6 @@
   make sure you don't set this for *nix guests; behavior may be
   unpredictable.
 
-- `deprecate_at` (string) - The date and time to deprecate the AMI, in UTC, in the following format: YYYY-MM-DDTHH:MM:SSZ.
-  If you specify a value for seconds, Amazon EC2 rounds the seconds to the nearest minute.
-  You can’t specify a date in the past. The upper limit for DeprecateAt is 10 years from now.
-
 - `fast_launch` (FastLaunchConfig) - The configuration for fast launch support.
   
   Fast launch is only relevant for Windows AMIs, and should not be used


### PR DESCRIPTION
Since the depreciation_time attribute implies being able to deprecate an AMI after a specific date, it should apply to any builder able to produce AMIs, that is everything but ebsvolume.

So this commit moves that to common, so all the builders (ebs, ebssurrogate, chroot and instance) are able to support it.

Closes #478 

