### PR TITLE
builder: remove instances of confighelper.Trilean

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -519,7 +519,7 @@ JSON example:
 
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
-- `associate_public_ip_address` (confighelper.Trilean) - If using a non-default VPC,
+- `associate_public_ip_address` (boolean) - If using a non-default VPC,
   public IP addresses are not provided by default. If this is true, your
   new instance will get a Public IP. default: unset
   

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -530,7 +530,7 @@ JSON example:
 
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
-- `associate_public_ip_address` (confighelper.Trilean) - If using a non-default VPC,
+- `associate_public_ip_address` (boolean) - If using a non-default VPC,
   public IP addresses are not provided by default. If this is true, your
   new instance will get a Public IP. default: unset
   

--- a/.web-docs/components/builder/ebsvolume/README.md
+++ b/.web-docs/components/builder/ebsvolume/README.md
@@ -484,7 +484,7 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
 
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
-- `associate_public_ip_address` (confighelper.Trilean) - If using a non-default VPC,
+- `associate_public_ip_address` (boolean) - If using a non-default VPC,
   public IP addresses are not provided by default. If this is true, your
   new instance will get a Public IP. default: unset
   

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -517,7 +517,7 @@ JSON example:
 
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
-- `associate_public_ip_address` (confighelper.Trilean) - If using a non-default VPC,
+- `associate_public_ip_address` (boolean) - If using a non-default VPC,
   public IP addresses are not provided by default. If this is true, your
   new instance will get a Public IP. default: unset
   

--- a/builder/chroot/step_create_volume_test.go
+++ b/builder/chroot/step_create_volume_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,17 +79,17 @@ func TestCreateVolume_gp2_to_io1(t *testing.T) {
 }
 
 func TestCreateVolume_Encrypted(t *testing.T) {
-	stepCreateVolume := StepCreateVolume{RootVolumeEncryptBoot: confighelper.TrileanFromBool(true)}
+	stepCreateVolume := StepCreateVolume{RootVolumeEncryptBoot: config.TrileanFromBool(true)}
 	testRootDevice := buildTestRootDevice()
 	ret, err := stepCreateVolume.buildCreateVolumeInput("test-az", testRootDevice)
 	assert.NoError(t, err)
 	// Ensure that the new value is equal to the the value passed in
-	assert.Equal(t, confighelper.TrileanFromBool(*ret.Encrypted), stepCreateVolume.RootVolumeEncryptBoot)
+	assert.Equal(t, config.TrileanFromBool(*ret.Encrypted), stepCreateVolume.RootVolumeEncryptBoot)
 }
 
 func TestCreateVolume_Custom_KMS_Key_Encrypted(t *testing.T) {
 	stepCreateVolume := StepCreateVolume{
-		RootVolumeEncryptBoot: confighelper.TrileanFromBool(true),
+		RootVolumeEncryptBoot: config.TrileanFromBool(true),
 		RootVolumeKmsKeyId:    "alias/1234",
 	}
 	testRootDevice := buildTestRootDevice()

--- a/builder/chroot/step_register_ami.go
+++ b/builder/chroot/step_register_ami.go
@@ -13,14 +13,14 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/random"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 // StepRegisterAMI creates the AMI.
 type StepRegisterAMI struct {
 	PollingConfig            *awscommon.AWSPollingConfig
 	RootVolumeSize           int64
-	EnableAMIENASupport      confighelper.Trilean
+	EnableAMIENASupport      config.Trilean
 	EnableAMISriovNetSupport bool
 	AMISkipBuildRegion       bool
 	BootMode                 string

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 	"github.com/hashicorp/packer-plugin-sdk/uuid"
 )
@@ -134,7 +133,7 @@ type RunConfig struct {
 	// `ec2:DescribeInstanceTypeOfferings` action to the role running the build.
 	// Otherwise, Packer will pick the most available subnet in the VPC selected,
 	// which may not be able to host the instance type you provided.
-	AssociatePublicIpAddress confighelper.Trilean `mapstructure:"associate_public_ip_address" required:"false"`
+	AssociatePublicIpAddress config.Trilean `mapstructure:"associate_public_ip_address" required:"false"`
 	// Destination availability zone to launch
 	// instance in. Leave this empty to allow Amazon to auto-assign.
 	AvailabilityZone string `mapstructure:"availability_zone" required:"false"`

--- a/builder/common/step_modify_ebs_instance.go
+++ b/builder/common/step_modify_ebs_instance.go
@@ -12,12 +12,12 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 type StepModifyEBSBackedInstance struct {
 	Skip                     bool
-	EnableAMIENASupport      confighelper.Trilean
+	EnableAMIENASupport      config.Trilean
 	EnableAMISriovNetSupport bool
 }
 
@@ -50,7 +50,7 @@ func (s *StepModifyEBSBackedInstance) Run(ctx context.Context, state multistep.S
 
 	// Handle EnaSupport flag.
 	// As of February 2017, this applies to C5, I3, P2, R4, X1, and m4.16xlarge
-	if s.EnableAMIENASupport != confighelper.TriUnset {
+	if s.EnableAMIENASupport != config.TriUnset {
 		var prefix string
 		if s.EnableAMIENASupport.True() {
 			prefix = "En"

--- a/builder/common/step_network_info.go
+++ b/builder/common/step_network_info.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 // StepNetworkInfo queries AWS for information about
@@ -31,7 +31,7 @@ type StepNetworkInfo struct {
 	VpcFilter                VpcFilterOptions
 	SubnetId                 string
 	SubnetFilter             SubnetFilterOptions
-	AssociatePublicIpAddress confighelper.Trilean
+	AssociatePublicIpAddress config.Trilean
 	AvailabilityZone         string
 	SecurityGroupIds         []string
 	SecurityGroupFilter      SecurityGroupFilterOptions
@@ -152,7 +152,7 @@ func (s *StepNetworkInfo) Run(ctx context.Context, state multistep.StateBag) mul
 
 	// Set VPC/Subnet if we explicitely enable or disable public IP assignment to the instance
 	// and we did not set or get a subnet ID before
-	if s.AssociatePublicIpAddress != confighelper.TriUnset && s.SubnetId == "" {
+	if s.AssociatePublicIpAddress != config.TriUnset && s.SubnetId == "" {
 		err := s.GetDefaultVPCAndSubnet(ui, ec2conn, state)
 		if err != nil {
 			ui.Say("associate_public_ip_address is set without a subnet_id.")

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -20,13 +20,13 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/retry"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
 type StepRunSourceInstance struct {
 	PollingConfig                     *AWSPollingConfig
-	AssociatePublicIpAddress          confighelper.Trilean
+	AssociatePublicIpAddress          config.Trilean
 	LaunchMappings                    EC2BlockDeviceMappingsBuilder
 	CapacityReservationPreference     string
 	CapacityReservationId             string
@@ -217,7 +217,7 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 
 	subnetId := state.Get("subnet_id").(string)
 
-	if subnetId != "" && s.AssociatePublicIpAddress != confighelper.TriUnset {
+	if subnetId != "" && s.AssociatePublicIpAddress != config.TriUnset {
 		ui.Say(fmt.Sprintf("changing public IP address config to %t for instance on subnet %q",
 			*s.AssociatePublicIpAddress.ToBoolPointer(),
 			subnetId))

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -21,7 +21,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/random"
 	"github.com/hashicorp/packer-plugin-sdk/retry"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
 )
 
@@ -31,7 +31,7 @@ type EC2BlockDeviceMappingsBuilder interface {
 
 type StepRunSpotInstance struct {
 	PollingConfig                     *AWSPollingConfig
-	AssociatePublicIpAddress          confighelper.Trilean
+	AssociatePublicIpAddress          config.Trilean
 	LaunchMappings                    EC2BlockDeviceMappingsBuilder
 	BlockDurationMinutes              int64
 	Debug                             bool
@@ -146,7 +146,7 @@ func (s *StepRunSpotInstance) CreateTemplateData(userData *string, az string,
 			DeviceIndex:         aws.Int64(0),
 			SubnetId:            aws.String(subnetId),
 		}
-		if s.AssociatePublicIpAddress != confighelper.TriUnset {
+		if s.AssociatePublicIpAddress != config.TriUnset {
 			ui.Say(fmt.Sprintf("changing public IP address config to %t for instance on subnet %q",
 				*s.AssociatePublicIpAddress.ToBoolPointer(),
 				subnetId))

--- a/builder/common/step_source_ami_info.go
+++ b/builder/common/step_source_ami_info.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 // StepSourceAMIInfo extracts critical information from the source AMI
@@ -24,7 +24,7 @@ import (
 type StepSourceAMIInfo struct {
 	SourceAmi                string
 	EnableAMISriovNetSupport bool
-	EnableAMIENASupport      confighelper.Trilean
+	EnableAMIENASupport      config.Trilean
 	AMIVirtType              string
 	AmiFilters               AmiFilterOptions
 	IncludeDeprecated        bool

--- a/builder/ebssurrogate/step_register_ami.go
+++ b/builder/ebssurrogate/step_register_ami.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/random"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 // StepRegisterAMI creates the AMI.
@@ -22,7 +22,7 @@ type StepRegisterAMI struct {
 	RootDevice               RootBlockDevice
 	AMIDevices               []*ec2.BlockDeviceMapping
 	LaunchDevices            []*ec2.BlockDeviceMapping
-	EnableAMIENASupport      confighelper.Trilean
+	EnableAMIENASupport      config.Trilean
 	EnableAMISriovNetSupport bool
 	Architecture             string
 	image                    *ec2.Image

--- a/builder/instance/step_register_ami.go
+++ b/builder/instance/step_register_ami.go
@@ -13,12 +13,12 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/random"
-	confighelper "github.com/hashicorp/packer-plugin-sdk/template/config"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
 )
 
 type StepRegisterAMI struct {
 	PollingConfig            *awscommon.AWSPollingConfig
-	EnableAMIENASupport      confighelper.Trilean
+	EnableAMIENASupport      config.Trilean
 	EnableAMISriovNetSupport bool
 	AMISkipBuildRegion       bool
 	TpmSupport               string

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -1,6 +1,6 @@
 <!-- Code generated from the comments of the RunConfig struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
 
-- `associate_public_ip_address` (confighelper.Trilean) - If using a non-default VPC,
+- `associate_public_ip_address` (boolean) - If using a non-default VPC,
   public IP addresses are not provided by default. If this is true, your
   new instance will get a Public IP. default: unset
   


### PR DESCRIPTION
Since most of those instances of confighelper were not necessary as there is not a config package, nor is there local name conflicts as well, we can remove those instaces, especially the one from Config as it caused the (fragile) typechecks from the SDK to not render it as a boolean in the web docs otherwise.

Related to https://github.com/hashicorp/packer-plugin-sdk/pull/244