### PR TITLE
docs: update placement configuration docs

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -945,13 +945,7 @@ JSON example:
   ]
   ```
   
-    - `host_resource_group_arn` (string) - The ARN of the host resource
-      group in which to launch the instances. If you specify a host
-      resource group ARN, omit the Tenancy parameter or set it to `host`.
-    - `tenancy` (string) - The tenancy of the instance (if the instance is
-      running in a VPC). An instance with a tenancy of `dedicated` runs on
-      single-tenant hardware. The default is `default`, meaning shared
-      tenancy. Allowed values are `default`, `dedicated` and `host`.
+  Refer to the [Placement docs](#placement-configuration) for more information on the supported attributes for placement configuration.
 
 - `tenancy` (string) - Deprecated: Use Placement Tenancy instead.
 
@@ -1066,6 +1060,23 @@ JSON example:
   This option is only used when `ssh_interface` is set `session_manager`.
 
 <!-- End of code generated from the comments of the RunConfig struct in builder/common/run_config.go; -->
+
+
+#### Placement Configuration
+
+<!-- Code generated from the comments of the Placement struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `host_resource_group_arn` (string) - The ARN of the host resource group in which to launch the instances.
+
+- `host_id` (string) - The ID of the host used when Packer launches an EC2 instance.
+
+- `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
+  when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+  
+  The default is "default", meaning shared tenancy. Allowed values are "default",
+  "dedicated" and "host".
+
+<!-- End of code generated from the comments of the Placement struct in builder/common/run_config.go; -->
 
 
 #### Metadata Settings

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -958,13 +958,7 @@ JSON example:
   ]
   ```
   
-    - `host_resource_group_arn` (string) - The ARN of the host resource
-      group in which to launch the instances. If you specify a host
-      resource group ARN, omit the Tenancy parameter or set it to `host`.
-    - `tenancy` (string) - The tenancy of the instance (if the instance is
-      running in a VPC). An instance with a tenancy of `dedicated` runs on
-      single-tenant hardware. The default is `default`, meaning shared
-      tenancy. Allowed values are `default`, `dedicated` and `host`.
+  Refer to the [Placement docs](#placement-configuration) for more information on the supported attributes for placement configuration.
 
 - `tenancy` (string) - Deprecated: Use Placement Tenancy instead.
 
@@ -1079,6 +1073,23 @@ JSON example:
   This option is only used when `ssh_interface` is set `session_manager`.
 
 <!-- End of code generated from the comments of the RunConfig struct in builder/common/run_config.go; -->
+
+
+#### Placement Configuration
+
+<!-- Code generated from the comments of the Placement struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `host_resource_group_arn` (string) - The ARN of the host resource group in which to launch the instances.
+
+- `host_id` (string) - The ID of the host used when Packer launches an EC2 instance.
+
+- `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
+  when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+  
+  The default is "default", meaning shared tenancy. Allowed values are "default",
+  "dedicated" and "host".
+
+<!-- End of code generated from the comments of the Placement struct in builder/common/run_config.go; -->
 
 
 #### Metadata Settings

--- a/.web-docs/components/builder/ebsvolume/README.md
+++ b/.web-docs/components/builder/ebsvolume/README.md
@@ -910,13 +910,7 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
   ]
   ```
   
-    - `host_resource_group_arn` (string) - The ARN of the host resource
-      group in which to launch the instances. If you specify a host
-      resource group ARN, omit the Tenancy parameter or set it to `host`.
-    - `tenancy` (string) - The tenancy of the instance (if the instance is
-      running in a VPC). An instance with a tenancy of `dedicated` runs on
-      single-tenant hardware. The default is `default`, meaning shared
-      tenancy. Allowed values are `default`, `dedicated` and `host`.
+  Refer to the [Placement docs](#placement-configuration) for more information on the supported attributes for placement configuration.
 
 - `tenancy` (string) - Deprecated: Use Placement Tenancy instead.
 
@@ -1031,6 +1025,23 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
   This option is only used when `ssh_interface` is set `session_manager`.
 
 <!-- End of code generated from the comments of the RunConfig struct in builder/common/run_config.go; -->
+
+
+#### Placement Configuration
+
+<!-- Code generated from the comments of the Placement struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `host_resource_group_arn` (string) - The ARN of the host resource group in which to launch the instances.
+
+- `host_id` (string) - The ID of the host used when Packer launches an EC2 instance.
+
+- `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
+  when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+  
+  The default is "default", meaning shared tenancy. Allowed values are "default",
+  "dedicated" and "host".
+
+<!-- End of code generated from the comments of the Placement struct in builder/common/run_config.go; -->
 
 
 #### Metadata Settings

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -943,13 +943,7 @@ JSON example:
   ]
   ```
   
-    - `host_resource_group_arn` (string) - The ARN of the host resource
-      group in which to launch the instances. If you specify a host
-      resource group ARN, omit the Tenancy parameter or set it to `host`.
-    - `tenancy` (string) - The tenancy of the instance (if the instance is
-      running in a VPC). An instance with a tenancy of `dedicated` runs on
-      single-tenant hardware. The default is `default`, meaning shared
-      tenancy. Allowed values are `default`, `dedicated` and `host`.
+  Refer to the [Placement docs](#placement-configuration) for more information on the supported attributes for placement configuration.
 
 - `tenancy` (string) - Deprecated: Use Placement Tenancy instead.
 
@@ -1177,6 +1171,23 @@ To close the SSM tunnels created, this plugin relies on being able to call
 In case this is not possible you might see a `Bad exit status` message in the logs.
 
 The absence of this permission won't prevent you from building the AMI, and the error only means that packer is not able to close the tunnel gracefully.
+
+
+#### Placement Configuration
+
+<!-- Code generated from the comments of the Placement struct in builder/common/run_config.go; DO NOT EDIT MANUALLY -->
+
+- `host_resource_group_arn` (string) - The ARN of the host resource group in which to launch the instances.
+
+- `host_id` (string) - The ID of the host used when Packer launches an EC2 instance.
+
+- `tenancy` (string) - [Tenancy](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html) used
+  when Packer launches the EC2 instance, allowing it to be launched on dedicated hardware.
+  
+  The default is "default", meaning shared tenancy. Allowed values are "default",
+  "dedicated" and "host".
+
+<!-- End of code generated from the comments of the Placement struct in builder/common/run_config.go; -->
 
 
 ### Block Devices Configuration

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -557,14 +557,7 @@ type RunConfig struct {
 	// ]
 	// ```
 	//
-	//   - `host_resource_group_arn` (string) - The ARN of the host resource
-	//     group in which to launch the instances. If you specify a host
-	//     resource group ARN, omit the Tenancy parameter or set it to `host`.
-	//   - `tenancy` (string) - The tenancy of the instance (if the instance is
-	//     running in a VPC). An instance with a tenancy of `dedicated` runs on
-	//     single-tenant hardware. The default is `default`, meaning shared
-	//     tenancy. Allowed values are `default`, `dedicated` and `host`.
-	//
+	// Refer to the [Placement docs](#placement-configuration) for more information on the supported attributes for placement configuration.
 	Placement Placement `mapstructure:"placement" required:"false"`
 	// Deprecated: Use Placement Tenancy instead.
 	Tenancy string `mapstructure:"tenancy" required:"false"`

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -426,13 +426,7 @@
   ]
   ```
   
-    - `host_resource_group_arn` (string) - The ARN of the host resource
-      group in which to launch the instances. If you specify a host
-      resource group ARN, omit the Tenancy parameter or set it to `host`.
-    - `tenancy` (string) - The tenancy of the instance (if the instance is
-      running in a VPC). An instance with a tenancy of `dedicated` runs on
-      single-tenant hardware. The default is `default`, meaning shared
-      tenancy. Allowed values are `default`, `dedicated` and `host`.
+  Refer to the [Placement docs](#placement-configuration) for more information on the supported attributes for placement configuration.
 
 - `tenancy` (string) - Deprecated: Use Placement Tenancy instead.
 

--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -93,6 +93,10 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'builder/common/RunConfig-not-required.mdx'
 
+#### Placement Configuration
+
+@include 'builder/common/Placement-not-required.mdx'
+
 #### Metadata Settings
 
 @include 'builder/common/MetadataOptions.mdx'

--- a/docs/builders/ebssurrogate.mdx
+++ b/docs/builders/ebssurrogate.mdx
@@ -89,6 +89,10 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'builder/common/RunConfig-not-required.mdx'
 
+#### Placement Configuration
+
+@include 'builder/common/Placement-not-required.mdx'
+
 #### Metadata Settings
 
 @include 'builder/common/MetadataOptions.mdx'

--- a/docs/builders/ebsvolume.mdx
+++ b/docs/builders/ebsvolume.mdx
@@ -94,6 +94,10 @@ Block devices can be nested in the
 
 @include 'builder/common/RunConfig-not-required.mdx'
 
+#### Placement Configuration
+
+@include 'builder/common/Placement-not-required.mdx'
+
 #### Metadata Settings
 
 @include 'builder/common/MetadataOptions.mdx'

--- a/docs/builders/instance.mdx
+++ b/docs/builders/instance.mdx
@@ -109,6 +109,10 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'builders/aws-session-manager.mdx'
 
+#### Placement Configuration
+
+@include 'builder/common/Placement-not-required.mdx'
+
 ### Block Devices Configuration
 
 Block devices can be nested in the


### PR DESCRIPTION
The placement configuration options were statically written as part of the placement docs instead of included through the generated partials, so this commit adds a section for those, and references that from where they were initially injected.

Closes #507 