### PR TITLE
Allow fast boot disable on region

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -1744,6 +1744,18 @@ https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/win-ami-config-fast-launc
 
 <!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
 
+- `enable_fast_launch` (boolean) - Enable fast launch allows you to disable fast launch settings on the region level.
+  
+  If unset, the default region behavior will be assumed - i.e. either use
+  the globally specified template ID/name (if specified), or AWS will set
+  it for you.
+  
+  Using other fast launch options, while unset, will imply enable_fast_launch to be true.
+  
+  If this is explicitly set to `false` fast-launch will be
+  disabled for the specified region and all other options besides region
+  will be ignored.
+
 - `template_id` (string) - The ID of the launch template to use for the fast launch
   
   This cannot be specified in conjunction with the template name.

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -1218,13 +1218,17 @@ func TestAccBuilder_EbsWindowsFastLaunchWithAMICopies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			currtest := tt
+
+			t.Parallel()
+
 			testcase := &acctest.PluginTestCase{
-				Name:     tt.name,
-				Template: fmt.Sprintf(tt.template, tt.amiName),
+				Name:     currtest.name,
+				Template: fmt.Sprintf(currtest.template, currtest.amiName),
 				Teardown: func() error {
 					var errs error
 
-					for _, ami := range tt.amiSpec {
+					for _, ami := range currtest.amiSpec {
 						err := ami.CleanUpAmi()
 						if err != nil {
 							t.Logf("cleaning up AMI %q in region %q failed: %s. It will need to be manually removed", ami.Name, ami.Region, err)
@@ -1239,7 +1243,7 @@ func TestAccBuilder_EbsWindowsFastLaunchWithAMICopies(t *testing.T) {
 						return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
 					}
 
-					for _, ami := range tt.amiSpec {
+					for _, ami := range currtest.amiSpec {
 						amis, err := ami.GetAmi()
 						if err != nil {
 							return fmt.Errorf("failed to get AMI: %s", err)
@@ -1287,7 +1291,7 @@ func TestAccBuilder_EbsWindowsFastLaunchWithAMICopies(t *testing.T) {
 						t.Fatalf("failed to read logs from logifle: %s", err)
 					}
 					logStr := string(logs)
-					for _, str := range tt.stringsToFindInLog {
+					for _, str := range currtest.stringsToFindInLog {
 						if !strings.Contains(logStr, str) {
 							t.Errorf("exptected to find %q in logs, but did not", str)
 						}

--- a/builder/ebs/fast_launch_setup.hcl2spec.go
+++ b/builder/ebs/fast_launch_setup.hcl2spec.go
@@ -45,6 +45,7 @@ func (*FlatFastLaunchConfig) HCL2Spec() map[string]hcldec.Spec {
 // FlatFastLaunchTemplateConfig is an auto-generated flat version of FastLaunchTemplateConfig.
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatFastLaunchTemplateConfig struct {
+	EnableFalseLaunch     *bool   `mapstructure:"enable_fast_launch" cty:"enable_fast_launch" hcl:"enable_fast_launch"`
 	Region                *string `mapstructure:"region" required:"true" cty:"region" hcl:"region"`
 	LaunchTemplateID      *string `mapstructure:"template_id" cty:"template_id" hcl:"template_id"`
 	LaunchTemplateName    *string `mapstructure:"template_name" cty:"template_name" hcl:"template_name"`
@@ -63,10 +64,11 @@ func (*FastLaunchTemplateConfig) FlatMapstructure() interface{ HCL2Spec() map[st
 // The decoded values from this spec will then be applied to a FlatFastLaunchTemplateConfig.
 func (*FlatFastLaunchTemplateConfig) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
-		"region":           &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
-		"template_id":      &hcldec.AttrSpec{Name: "template_id", Type: cty.String, Required: false},
-		"template_name":    &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
-		"template_version": &hcldec.AttrSpec{Name: "template_version", Type: cty.Number, Required: false},
+		"enable_fast_launch": &hcldec.AttrSpec{Name: "enable_fast_launch", Type: cty.Bool, Required: false},
+		"region":             &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
+		"template_id":        &hcldec.AttrSpec{Name: "template_id", Type: cty.String, Required: false},
+		"template_name":      &hcldec.AttrSpec{Name: "template_name", Type: cty.String, Required: false},
+		"template_version":   &hcldec.AttrSpec{Name: "template_version", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/ebs/step_enable_fast_launch.go
+++ b/builder/ebs/step_enable_fast_launch.go
@@ -74,6 +74,14 @@ func (s *stepEnableFastLaunch) Run(ctx context.Context, state multistep.StateBag
 		go func(region, ami string) {
 			defer wg.Done()
 
+			// Immediately return if we don't want fast-launch for a
+			// particular region
+			templateIDsByRegion, ok := state.GetOk("launch_template_version")
+			if ok && !templateIDsByRegion.(map[string]TemplateSpec)[region].Enabled {
+				log.Printf("skipping fast launch for region %q", region)
+				return
+			}
+
 			// Casting is somewhat unsafe, but since the retryer below only
 			// accepts this type, and not ec2iface.EC2API, we can safely
 			// do this here, unless the `GetRegionConn` function evolves

--- a/docs-partials/builder/ebs/FastLaunchTemplateConfig-not-required.mdx
+++ b/docs-partials/builder/ebs/FastLaunchTemplateConfig-not-required.mdx
@@ -1,5 +1,17 @@
 <!-- Code generated from the comments of the FastLaunchTemplateConfig struct in builder/ebs/fast_launch_setup.go; DO NOT EDIT MANUALLY -->
 
+- `enable_fast_launch` (boolean) - Enable fast launch allows you to disable fast launch settings on the region level.
+  
+  If unset, the default region behavior will be assumed - i.e. either use
+  the globally specified template ID/name (if specified), or AWS will set
+  it for you.
+  
+  Using other fast launch options, while unset, will imply enable_fast_launch to be true.
+  
+  If this is explicitly set to `false` fast-launch will be
+  disabled for the specified region and all other options besides region
+  will be ignored.
+
 - `template_id` (string) - The ID of the launch template to use for the fast launch
   
   This cannot be specified in conjunction with the template name.


### PR DESCRIPTION
The fast-launch configuration allows setupping fast-launch for Windows virtual machines, either with a common configuration, or with a region-by-region configuration.
However if someone wants to only enable fast-launch on a subset of regions, there wasn't any way to express that, leading to either a waste of resources, or a need to manually cleanup the extra snapshots created.

Therefore this commit adds an extra trilean to the regional configuration for fast-launch, so it can be explicitly disabled on selected regions.

Closes: #506 

