### PR TITLE
Log when skipping instance stop for spot instances

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -581,6 +581,10 @@ JSON example:
   -> Note: The double quotation marks in the command are not required if
   your CMD shell is already in the
   `C:\Program Files\Amazon\EC2ConfigService\` directory.
+  
+  Note that when using a spot instance, Packer doesn't stop the instance,
+  regardless of the value of this setting. Instead, it relies on the CreateImage
+  call to stop and restart the instance.
 
 - `ebs_optimized` (bool) - Mark instance as [EBS
   Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -594,6 +594,10 @@ JSON example:
   -> Note: The double quotation marks in the command are not required if
   your CMD shell is already in the
   `C:\Program Files\Amazon\EC2ConfigService\` directory.
+  
+  Note that when using a spot instance, Packer doesn't stop the instance,
+  regardless of the value of this setting. Instead, it relies on the CreateImage
+  call to stop and restart the instance.
 
 - `ebs_optimized` (bool) - Mark instance as [EBS
   Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).

--- a/.web-docs/components/builder/ebsvolume/README.md
+++ b/.web-docs/components/builder/ebsvolume/README.md
@@ -546,6 +546,10 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
   -> Note: The double quotation marks in the command are not required if
   your CMD shell is already in the
   `C:\Program Files\Amazon\EC2ConfigService\` directory.
+  
+  Note that when using a spot instance, Packer doesn't stop the instance,
+  regardless of the value of this setting. Instead, it relies on the CreateImage
+  call to stop and restart the instance.
 
 - `ebs_optimized` (bool) - Mark instance as [EBS
   Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -579,6 +579,10 @@ JSON example:
   -> Note: The double quotation marks in the command are not required if
   your CMD shell is already in the
   `C:\Program Files\Amazon\EC2ConfigService\` directory.
+  
+  Note that when using a spot instance, Packer doesn't stop the instance,
+  regardless of the value of this setting. Instead, it relies on the CreateImage
+  call to stop and restart the instance.
 
 - `ebs_optimized` (bool) - Mark instance as [EBS
   Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -178,6 +178,10 @@ type RunConfig struct {
 	// -> Note: The double quotation marks in the command are not required if
 	// your CMD shell is already in the
 	// `C:\Program Files\Amazon\EC2ConfigService\` directory.
+        //
+        // Note that when using a spot instance, Packer doesn't stop the instance,
+        // regardless of the value of this setting. Instead, it relies on the CreateImage
+        // call to stop and restart the instance.
 	DisableStopInstance bool `mapstructure:"disable_stop_instance" required:"false"`
 	// Mark instance as [EBS
 	// Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).

--- a/builder/common/step_stop_ebs_instance.go
+++ b/builder/common/step_stop_ebs_instance.go
@@ -28,6 +28,7 @@ func (s *StepStopEBSBackedInstance) Run(ctx context.Context, state multistep.Sta
 
 	// Skip when it is a spot instance
 	if s.Skip {
+		ui.Say("Skipping instance stop, since this is a spot instance.")
 		return multistep.ActionContinue
 	}
 

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -62,6 +62,10 @@
   -> Note: The double quotation marks in the command are not required if
   your CMD shell is already in the
   `C:\Program Files\Amazon\EC2ConfigService\` directory.
+  
+  Note that when using a spot instance, Packer doesn't stop the instance,
+  regardless of the value of this setting. Instead, it relies on the CreateImage
+  call to stop and restart the instance.
 
 - `ebs_optimized` (bool) - Mark instance as [EBS
   Optimized](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSOptimized.html).


### PR DESCRIPTION
This should make it clearer what's going on.

Also update the documentation to mention this behavior.

Closes #448.
