### PR TITLE
Fix 2022 sysprep provisioner cmd

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -2215,6 +2215,34 @@ build {
 }
 ```
 
+## Windows 2022 Sysprep Commands - For Amazon Windows AMIs Only
+
+For Amazon Windows 2022 AMIs it is necessary to run Sysprep commands which can
+be easily added to the provisioner section.
+
+**HCL2**
+
+```hcl
+provisioner "powershell" {
+  inline = [
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --shutdown --block"
+  ]
+}
+```
+
+**JSON**
+
+```json
+{
+  "type": "powershell",
+  "inline": [
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --shutdown --block"
+  ]
+}
+```
+
 
 ## Windows 2016 Sysprep Commands - For Amazon Windows AMIs Only
 

--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -673,6 +673,34 @@ build {
 }
 ```
 
+## Windows 2022 Sysprep Commands - For Amazon Windows AMIs Only
+
+For Amazon Windows 2022 AMIs it is necessary to run Sysprep commands which can
+be easily added to the provisioner section.
+
+**HCL2**
+
+```hcl
+provisioner "powershell" {
+  inline = [
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --shutdown --block"
+  ]
+}
+```
+
+**JSON**
+
+```json
+{
+  "type": "powershell",
+  "inline": [
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' reset --block",
+    "& 'C:/Program Files/Amazon/EC2Launch/ec2launch' sysprep --shutdown --block"
+  ]
+}
+```
+
 
 ## Windows 2016 Sysprep Commands - For Amazon Windows AMIs Only
 


### PR DESCRIPTION
The sysprep commands currently in the documentation do not work anymore. That is because they are written for EC2Launch v1. V2 moved to new executables in a different location where previously v1 used scripts. v2 is the default for all windows AMIs now as far as i can tell.

The new addition to the docs I have confirmed work for 2022. However, I was not able to get a 2016 or 2019 server working with sysprep provisioners commands. I'm leaving them as is 

