### PR TITLE
 Skip attaching run tags to the finished AMI.

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -40,6 +40,8 @@ necessary for this build to succeed and can be found further down the page.
 - `skip_create_ami` (bool) - If true, Packer will not create the AMI. Useful for setting to `true`
   during a build test stage. Default `false`.
 
+- `skip_ami_run_tags` (bool) - If true will not propagate the run tags set on Packer created instance to the AMI created.
+
 - `ami_block_device_mappings` (awscommon.BlockDevices) - Add one or more block device mappings to the AMI. These will be attached
   when booting a new instance from your AMI. To add a block device during
   the Packer build see `launch_block_device_mappings` below. Your options

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -52,6 +52,8 @@ necessary for this build to succeed and can be found further down the page.
   here may vary depending on the type of VM you use. See the
   [BlockDevices](#block-devices-configuration) documentation for fields.
 
+- `skip_ami_run_tags` (bool) - If true will not propagate the run tags set on Packer created instance to the AMI created.
+
 - `launch_block_device_mappings` (BlockDevices) - Add one or more block devices before the Packer build starts. If you add
   instance store volumes or EBS volumes in addition to the root device
   volume, the created AMI will contain block device mapping information

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -40,6 +40,10 @@ type Config struct {
 	// If true, Packer will not create the AMI. Useful for setting to `true`
 	// during a build test stage. Default `false`.
 	AMISkipCreateImage bool `mapstructure:"skip_create_ami" required:"false"`
+
+	// If true will not propagate the run tags set on Packer created instance to the AMI created.
+	AMISkipRunTags bool `mapstructure:"skip_ami_run_tags" required:"false"`
+
 	// Add one or more block device mappings to the AMI. These will be attached
 	// when booting a new instance from your AMI. To add a block device during
 	// the Packer build see `launch_block_device_mappings` below. Your options
@@ -405,6 +409,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		&stepCreateAMI{
 			AMISkipCreateImage: b.config.AMISkipCreateImage,
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+			AMISkipRunTags:     b.config.AMISkipRunTags,
 			PollingConfig:      b.config.PollingConfig,
 			IsRestricted:       b.config.IsChinaCloud() || b.config.IsGovCloud(),
 			Tags:               b.config.RunTags,

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -159,6 +159,7 @@ type FlatConfig struct {
 	PauseBeforeSSM                            *string                                     `mapstructure:"pause_before_ssm" cty:"pause_before_ssm" hcl:"pause_before_ssm"`
 	SessionManagerPort                        *int                                        `mapstructure:"session_manager_port" cty:"session_manager_port" hcl:"session_manager_port"`
 	AMISkipCreateImage                        *bool                                       `mapstructure:"skip_create_ami" required:"false" cty:"skip_create_ami" hcl:"skip_create_ami"`
+	AMISkipRunTags                            *bool                                       `mapstructure:"skip_ami_run_tags" required:"false" cty:"skip_ami_run_tags" hcl:"skip_ami_run_tags"`
 	AMIMappings                               []common.FlatBlockDevice                    `mapstructure:"ami_block_device_mappings" required:"false" cty:"ami_block_device_mappings" hcl:"ami_block_device_mappings"`
 	LaunchMappings                            []common.FlatBlockDevice                    `mapstructure:"launch_block_device_mappings" required:"false" cty:"launch_block_device_mappings" hcl:"launch_block_device_mappings"`
 	VolumeRunTags                             map[string]string                           `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
@@ -326,6 +327,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"pause_before_ssm":             &hcldec.AttrSpec{Name: "pause_before_ssm", Type: cty.String, Required: false},
 		"session_manager_port":         &hcldec.AttrSpec{Name: "session_manager_port", Type: cty.Number, Required: false},
 		"skip_create_ami":              &hcldec.AttrSpec{Name: "skip_create_ami", Type: cty.Bool, Required: false},
+		"skip_ami_run_tags":            &hcldec.AttrSpec{Name: "skip_ami_run_tags", Type: cty.Bool, Required: false},
 		"ami_block_device_mappings":    &hcldec.BlockListSpec{TypeName: "ami_block_device_mappings", Nested: hcldec.ObjectSpec((*common.FlatBlockDevice)(nil).HCL2Spec())},
 		"launch_block_device_mappings": &hcldec.BlockListSpec{TypeName: "launch_block_device_mappings", Nested: hcldec.ObjectSpec((*common.FlatBlockDevice)(nil).HCL2Spec())},
 		"run_volume_tags":              &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -726,7 +726,7 @@ func TestAccBuilder_EbsRunTagsJSON(t *testing.T) {
 var testInterpolatedSkipRunTagsSource string
 
 func TestAccBuilder_EbsSkipAmiRunTags(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	ami := amazon_acc.AMIHelper{
 		Region: "us-east-1",
 		Name:   fmt.Sprintf("packer-amazon-skip-ami-run-tags-test %d", time.Now().Unix()),

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -728,7 +728,7 @@ var testInterpolatedSkipRunTagsSource string
 func TestAccBuilder_EbsSkipAmiRunTags(t *testing.T) {
 	//t.Parallel()
 	ami := amazon_acc.AMIHelper{
-		Region: "us-west-2",
+		Region: "us-east-1",
 		Name:   fmt.Sprintf("packer-amazon-skip-ami-run-tags-test %d", time.Now().Unix()),
 	}
 
@@ -762,9 +762,9 @@ func TestAccBuilder_EbsSkipAmiRunTags(t *testing.T) {
 var testInterpolatedSkipRunTagsCreateAmiTagsSource string
 
 func TestAccBuilder_EbsSkipAmiRunTagsCreateAmiTags(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	ami := amazon_acc.AMIHelper{
-		Region: "us-west-2",
+		Region: "us-east-1",
 		Name:   fmt.Sprintf("packer-amazon-skip-ami-run-tags-create-ami-tags-test %d", time.Now().Unix()),
 	}
 

--- a/builder/ebs/builder_acc_test.go
+++ b/builder/ebs/builder_acc_test.go
@@ -726,7 +726,7 @@ func TestAccBuilder_EbsRunTagsJSON(t *testing.T) {
 var testInterpolatedSkipRunTagsSource string
 
 func TestAccBuilder_EbsSkipAmiRunTags(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	ami := amazon_acc.AMIHelper{
 		Region: "us-west-2",
 		Name:   fmt.Sprintf("packer-amazon-skip-ami-run-tags-test %d", time.Now().Unix()),

--- a/builder/ebs/step_create_ami.go
+++ b/builder/ebs/step_create_ami.go
@@ -76,10 +76,10 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 		}
 
 		if !s.AMISkipRunTags {
-			ui.Say(fmt.Sprintf("Attaching run tags to AMI..."))
+			ui.Say("Attaching run tags to AMI...")
 			createOpts.TagSpecifications = ec2Tags.TagSpecifications(ec2.ResourceTypeImage, ec2.ResourceTypeSnapshot)
 		} else {
-			ui.Say(fmt.Sprintf("Skipping attaching run tags to AMI..."))
+			ui.Say("Skipping attaching run tags to AMI...")
 		}
 	}
 

--- a/builder/ebs/step_create_ami.go
+++ b/builder/ebs/step_create_ami.go
@@ -25,6 +25,7 @@ type stepCreateAMI struct {
 	image              *ec2.Image
 	AMISkipCreateImage bool
 	AMISkipBuildRegion bool
+	AMISkipRunTags     bool
 	IsRestricted       bool
 	Ctx                interpolate.Context
 	Tags               map[string]string
@@ -74,7 +75,12 @@ func (s *stepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 			return multistep.ActionHalt
 		}
 
-		createOpts.TagSpecifications = ec2Tags.TagSpecifications(ec2.ResourceTypeImage, ec2.ResourceTypeSnapshot)
+		if !s.AMISkipRunTags {
+			ui.Say(fmt.Sprintf("Attaching run tags to AMI..."))
+			createOpts.TagSpecifications = ec2Tags.TagSpecifications(ec2.ResourceTypeImage, ec2.ResourceTypeSnapshot)
+		} else {
+			ui.Say(fmt.Sprintf("Skipping attaching run tags to AMI..."))
+		}
 	}
 
 	var createResp *ec2.CreateImageOutput

--- a/builder/ebs/test-fixtures/interpolated_run_tags.pkr.hcl
+++ b/builder/ebs/test-fixtures/interpolated_run_tags.pkr.hcl
@@ -26,11 +26,11 @@ source "amazon-ebs" "basic-example" {
   ssh_username  = "ubuntu"
 
   run_tags = {
-    "build_name" = "{{build_name}}"
+    "build_name"  = "{{build_name}}"
     "source_name" = source.name
-    "version"    = packer.version
-    "built_by"   = var.builder
-    "simple"     = "Simple String"
+    "version"     = packer.version
+    "built_by"    = var.builder
+    "simple"      = "Simple String"
   }
 }
 

--- a/builder/ebs/test-fixtures/interpolated_skip_run_tags.pkr.hcl
+++ b/builder/ebs/test-fixtures/interpolated_skip_run_tags.pkr.hcl
@@ -1,37 +1,26 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-data "amazon-ami" "test" {
-  filters = {
-    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
-    root-device-type    = "ebs"
-    virtualization-type = "hvm"
-  }
-  most_recent = true
-  owners      = ["099720109477"]
-  region      = "us-west-2"
-}
-
 variable "builder" {
   type    = string
   default = "Packer"
 }
 
 source "amazon-ebs" "basic-example" {
-  region        = "us-west-2"
-  source_ami    = data.amazon-ami.test.id
-  instance_type = "t2.micro"
-  ami_name      = "%s"
-  communicator  = "ssh"
-  ssh_username  = "ubuntu"
+  region            = "us-east-1"
+  source_ami        = "ami-76b2a71e"
+  instance_type     = "t2.micro"
+  ami_name          = "%s"
+  communicator      = "ssh"
+  ssh_username      = "ubuntu"
   skip_ami_run_tags = true
 
   run_tags = {
-    "build_name" = "{{build_name}}"
+    "build_name"  = "{{build_name}}"
     "source_name" = source.name
-    "version"    = packer.version
-    "built_by"   = var.builder
-    "simple"     = "Simple String"
+    "version"     = packer.version
+    "built_by"    = var.builder
+    "simple"      = "Simple String"
   }
 }
 

--- a/builder/ebs/test-fixtures/interpolated_skip_run_tags.pkr.hcl
+++ b/builder/ebs/test-fixtures/interpolated_skip_run_tags.pkr.hcl
@@ -1,0 +1,42 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "amazon-ami" "test" {
+  filters = {
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["099720109477"]
+  region      = "us-west-2"
+}
+
+variable "builder" {
+  type    = string
+  default = "Packer"
+}
+
+source "amazon-ebs" "basic-example" {
+  region        = "us-west-2"
+  source_ami    = data.amazon-ami.test.id
+  instance_type = "t2.micro"
+  ami_name      = "%s"
+  communicator  = "ssh"
+  ssh_username  = "ubuntu"
+  skip_ami_run_tags = true
+
+  run_tags = {
+    "build_name" = "{{build_name}}"
+    "source_name" = source.name
+    "version"    = packer.version
+    "built_by"   = var.builder
+    "simple"     = "Simple String"
+  }
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.basic-example"
+  ]
+}

--- a/builder/ebs/test-fixtures/interpolated_skip_run_tags_create_ami_tags.pkr.hcl
+++ b/builder/ebs/test-fixtures/interpolated_skip_run_tags_create_ami_tags.pkr.hcl
@@ -1,40 +1,29 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
-data "amazon-ami" "test" {
-  filters = {
-    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
-    root-device-type    = "ebs"
-    virtualization-type = "hvm"
-  }
-  most_recent = true
-  owners      = ["099720109477"]
-  region      = "us-west-2"
-}
-
 variable "builder" {
   type    = string
   default = "Packer"
 }
 
 source "amazon-ebs" "basic-example" {
-  region        = "us-west-2"
-  source_ami    = data.amazon-ami.test.id
-  instance_type = "t2.micro"
-  ami_name      = "%s"
-  communicator  = "ssh"
-  ssh_username  = "ubuntu"
+  region            = "us-east-1"
+  source_ami        = "ami-76b2a71e"
+  instance_type     = "t2.micro"
+  ami_name          = "%s"
+  communicator      = "ssh"
+  ssh_username      = "ubuntu"
   skip_ami_run_tags = true
 
   run_tags = {
-    "build_name" = "{{build_name}}"
+    "build_name"  = "{{build_name}}"
     "source_name" = source.name
-    "version"    = packer.version
-    "built_by"   = var.builder
-    "simple"     = "Simple String"
+    "version"     = packer.version
+    "built_by"    = var.builder
+    "simple"      = "Simple String"
   }
   tags = {
-    "ami_tag" = "yes"    
+    "ami_tag" = "yes"
   }
 }
 

--- a/builder/ebs/test-fixtures/interpolated_skip_run_tags_create_ami_tags.pkr.hcl
+++ b/builder/ebs/test-fixtures/interpolated_skip_run_tags_create_ami_tags.pkr.hcl
@@ -1,0 +1,45 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "amazon-ami" "test" {
+  filters = {
+    name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
+    root-device-type    = "ebs"
+    virtualization-type = "hvm"
+  }
+  most_recent = true
+  owners      = ["099720109477"]
+  region      = "us-west-2"
+}
+
+variable "builder" {
+  type    = string
+  default = "Packer"
+}
+
+source "amazon-ebs" "basic-example" {
+  region        = "us-west-2"
+  source_ami    = data.amazon-ami.test.id
+  instance_type = "t2.micro"
+  ami_name      = "%s"
+  communicator  = "ssh"
+  ssh_username  = "ubuntu"
+  skip_ami_run_tags = true
+
+  run_tags = {
+    "build_name" = "{{build_name}}"
+    "source_name" = source.name
+    "version"    = packer.version
+    "built_by"   = var.builder
+    "simple"     = "Simple String"
+  }
+  tags = {
+    "ami_tag" = "yes"    
+  }
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.basic-example"
+  ]
+}

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -43,6 +43,9 @@ type Config struct {
 	// here may vary depending on the type of VM you use. See the
 	// [BlockDevices](#block-devices-configuration) documentation for fields.
 	AMIMappings awscommon.BlockDevices `mapstructure:"ami_block_device_mappings" required:"false"`
+	// If true will not propagate the run tags set on Packer created instance to the AMI created.
+	AMISkipRunTags bool `mapstructure:"skip_ami_run_tags" required:"false"`
+
 	// Add one or more block devices before the Packer build starts. If you add
 	// instance store volumes or EBS volumes in addition to the root device
 	// volume, the created AMI will contain block device mapping information
@@ -343,6 +346,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 		buildAmiStep = &StepCreateAMI{
 			AMISkipBuildRegion: b.config.AMISkipBuildRegion,
+			AMISkipRunTags:     b.config.AMISkipRunTags,
 			RootDevice:         b.config.RootDevice,
 			AMIDevices:         amiDevices,
 			LaunchDevices:      launchDevices,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -205,6 +205,7 @@ type FlatConfig struct {
 	DeregistrationProtection                  *common.FlatDeregistrationProtectionOptions `mapstructure:"deregistration_protection" required:"false" cty:"deregistration_protection" hcl:"deregistration_protection"`
 	SnapshotDescription                       *string                                     `mapstructure:"snapshot_description" required:"false" cty:"snapshot_description" hcl:"snapshot_description"`
 	AMIMappings                               []common.FlatBlockDevice                    `mapstructure:"ami_block_device_mappings" required:"false" cty:"ami_block_device_mappings" hcl:"ami_block_device_mappings"`
+	AMISkipRunTags                            *bool                                       `mapstructure:"skip_ami_run_tags" required:"false" cty:"skip_ami_run_tags" hcl:"skip_ami_run_tags"`
 	LaunchMappings                            []FlatBlockDevice                           `mapstructure:"launch_block_device_mappings" required:"false" cty:"launch_block_device_mappings" hcl:"launch_block_device_mappings"`
 	RootDevice                                *FlatRootBlockDevice                        `mapstructure:"ami_root_device" required:"true" cty:"ami_root_device" hcl:"ami_root_device"`
 	VolumeRunTags                             map[string]string                           `mapstructure:"run_volume_tags" cty:"run_volume_tags" hcl:"run_volume_tags"`
@@ -376,6 +377,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"deregistration_protection":    &hcldec.BlockSpec{TypeName: "deregistration_protection", Nested: hcldec.ObjectSpec((*common.FlatDeregistrationProtectionOptions)(nil).HCL2Spec())},
 		"snapshot_description":         &hcldec.AttrSpec{Name: "snapshot_description", Type: cty.String, Required: false},
 		"ami_block_device_mappings":    &hcldec.BlockListSpec{TypeName: "ami_block_device_mappings", Nested: hcldec.ObjectSpec((*common.FlatBlockDevice)(nil).HCL2Spec())},
+		"skip_ami_run_tags":            &hcldec.AttrSpec{Name: "skip_ami_run_tags", Type: cty.Bool, Required: false},
 		"launch_block_device_mappings": &hcldec.BlockListSpec{TypeName: "launch_block_device_mappings", Nested: hcldec.ObjectSpec((*FlatBlockDevice)(nil).HCL2Spec())},
 		"ami_root_device":              &hcldec.BlockSpec{TypeName: "ami_root_device", Nested: hcldec.ObjectSpec((*FlatRootBlockDevice)(nil).HCL2Spec())},
 		"run_volume_tags":              &hcldec.AttrSpec{Name: "run_volume_tags", Type: cty.Map(cty.String), Required: false},

--- a/builder/ebssurrogate/builder_acc_test.go
+++ b/builder/ebssurrogate/builder_acc_test.go
@@ -4,6 +4,7 @@
 package ebssurrogate
 
 import (
+	_ "embed"
 	"fmt"
 	"os"
 	"os/exec"
@@ -73,6 +74,9 @@ func checkAMITags(ami amazon_acc.AMIHelper, tagList map[string]string) error {
 	return errs
 }
 
+//go:embed test-fixtures/interpolated_ebs_surrogate_basic.pkr.hcl
+var testBuilderAccBasic string
+
 func TestAccBuilder_EbssurrogateBasic(t *testing.T) {
 	t.Parallel()
 	ami := amazon_acc.AMIHelper{
@@ -96,6 +100,9 @@ func TestAccBuilder_EbssurrogateBasic(t *testing.T) {
 	}
 	acctest.TestPlugin(t, testCase)
 }
+
+//go:embed test-fixtures/interpolated_skip_run_tags.pkr.hcl
+var testBuilderAccBasicSkipAmiRunTags string
 
 func TestAccBuilder_EbssurrogateBasicSkipAmiRunTags(t *testing.T) {
 	t.Parallel()
@@ -127,6 +134,9 @@ func TestAccBuilder_EbssurrogateBasicSkipAmiRunTags(t *testing.T) {
 	}
 	acctest.TestPlugin(t, testCase)
 }
+
+//go:embed test-fixtures/interpolated_ebs_surrogate_basic_imdsv2.pkr.hcl
+var testBuilderAccBasicIMDSv2 string
 
 func TestAccBuilder_EbssurrogateBasic_forceIMDSv2(t *testing.T) {
 	t.Parallel()
@@ -168,6 +178,9 @@ func TestAccBuilder_EbssurrogateBasic_forceIMDSv2(t *testing.T) {
 	acctest.TestPlugin(t, testCase)
 }
 
+//go:embed test-fixtures/interpolated_ebs_surrogate_private_key_file.pkr.hcl
+var testPrivateKeyFile string
+
 func TestAccBuilder_Ebssurrogate_SSHPrivateKeyFile_SSM(t *testing.T) {
 	t.Parallel()
 	if os.Getenv(acctest.TestEnvVar) == "" {
@@ -205,6 +218,9 @@ func TestAccBuilder_Ebssurrogate_SSHPrivateKeyFile_SSM(t *testing.T) {
 	acctest.TestPlugin(t, testcase)
 }
 
+//go:embed test-fixtures/interpolated_ebs_surrogate_create_image.pkr.hcl
+var testBuilderAccUseCreateImageTrue string
+
 func TestAccBuilder_EbssurrogateUseCreateImageTrue(t *testing.T) {
 	t.Parallel()
 	ami := amazon_acc.AMIHelper{
@@ -228,6 +244,9 @@ func TestAccBuilder_EbssurrogateUseCreateImageTrue(t *testing.T) {
 	}
 	acctest.TestPlugin(t, testCase)
 }
+
+//go:embed test-fixtures/interpolated_ebs_surrogate_create_image_false.pkr.hcl
+var testBuilderAccUseCreateImageFalse string
 
 func TestAccBuilder_EbssurrogateUseCreateImageFalse(t *testing.T) {
 	t.Parallel()
@@ -253,6 +272,9 @@ func TestAccBuilder_EbssurrogateUseCreateImageFalse(t *testing.T) {
 	acctest.TestPlugin(t, testCase)
 }
 
+//go:embed test-fixtures/interpolated_ebs_surrogate_create_image_optional.pkr.hcl
+var testBuilderAccUseCreateImageOptional string
+
 func TestAccBuilder_EbssurrogateUseCreateImageOptional(t *testing.T) {
 	t.Parallel()
 	ami := amazon_acc.AMIHelper{
@@ -276,6 +298,9 @@ func TestAccBuilder_EbssurrogateUseCreateImageOptional(t *testing.T) {
 	}
 	acctest.TestPlugin(t, testCase)
 }
+
+//go:embed test-fixtures/interpolated_ebs_surrogate_with_deprecate_at.pkr.hcl
+var testBuilderAcc_WithDeprecateAt string
 
 func TestAccBuilder_EbssurrogateWithAMIDeprecate(t *testing.T) {
 	t.Parallel()
@@ -330,239 +355,3 @@ func TestAccBuilder_EbssurrogateWithAMIDeprecate(t *testing.T) {
 	}
 	acctest.TestPlugin(t, testCase)
 }
-
-const testBuilderAccBasic = `
-source "amazon-ebssurrogate" "test" {
-	ami_name = "%s"
-	region = "us-east-1"
-	instance_type = "m3.medium"
-	source_ami = "ami-76b2a71e"
-	ssh_username = "ubuntu"
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`
-
-const testBuilderAccBasicSkipAmiRunTags = `
-source "amazon-ebssurrogate" "test" {
-	ami_name = "%s"
-	region = "us-east-1"
-	instance_type = "m3.medium"
-	source_ami = "ami-76b2a71e"
-	ssh_username = "ubuntu"
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	run_tags = {
-    	"simple" = "Simple String"
-  }
-
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`
-
-const testBuilderAccBasicIMDSv2 = `
-source "amazon-ebssurrogate" "test" {
-	ami_name = "%s"
-	region = "us-east-1"
-	instance_type = "m3.medium"
-	source_ami = "ami-76b2a71e"
-	ssh_username = "ubuntu"
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	imds_support = "v2.0"
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`
-
-const testPrivateKeyFile = `
-source "amazon-ebssurrogate" "test" {
-	ami_name             = "%s"
-	source_ami           = "ami-0b5eea76982371e91" # Amazon Linux 2 AMI - kernel 5.10
-	instance_type        = "m3.medium"
-	region               = "us-east-1"
-	ssh_username         = "ec2-user"
-	ssh_interface        = "session_manager"
-	iam_instance_profile = "SSMInstanceProfile"
-	communicator         = "ssh"
-	ssh_private_key_file = "%s"
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`
-
-const testBuilderAccUseCreateImageTrue = `
-source "amazon-ebssurrogate" "test" {
-	ami_name = "%s"
-	region = "us-east-1"
-	instance_type = "m3.medium"
-	source_ami = "ami-76b2a71e"
-	ssh_username = "ubuntu"
-	use_create_image = true
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`
-
-const testBuilderAccUseCreateImageFalse = `
-source "amazon-ebssurrogate" "test" {
-	ami_name = "%s"
-	region = "us-east-1"
-	instance_type = "m3.medium"
-	source_ami = "ami-76b2a71e"
-	ssh_username = "ubuntu"
-	use_create_image = false
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`
-
-const testBuilderAccUseCreateImageOptional = `
-source "amazon-ebssurrogate" "test" {
-	ami_name = "%s"
-	region = "us-east-1"
-	instance_type = "m3.medium"
-	source_ami = "ami-76b2a71e"
-	ssh_username = "ubuntu"
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`
-
-const testBuilderAcc_WithDeprecateAt = `
-source "amazon-ebssurrogate" "test" {
-	ami_name = "%s"
-	region = "us-east-1"
-	instance_type = "m3.medium"
-	source_ami = "ami-76b2a71e"
-	ssh_username = "ubuntu"
-	launch_block_device_mappings {
-		device_name = "/dev/xvda"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	ami_virtualization_type = "hvm"
-	ami_root_device {
-		source_device_name = "/dev/xvda"
-		device_name = "/dev/sda1"
-		delete_on_termination = true
-		volume_size = 8
-		volume_type = "gp2"
-	}
-	deprecate_at = "%s"
-}
-
-build {
-	sources = ["amazon-ebssurrogate.test"]
-}
-`

--- a/builder/ebssurrogate/step_create_ami.go
+++ b/builder/ebssurrogate/step_create_ami.go
@@ -28,6 +28,7 @@ type StepCreateAMI struct {
 	LaunchOmitMap      map[string]bool
 	image              *ec2.Image
 	AMISkipBuildRegion bool
+	AMISkipRunTags     bool
 	IsRestricted       bool
 	Ctx                interpolate.Context
 	Tags               map[string]string
@@ -72,6 +73,12 @@ func (s *StepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 			state.Put("error", err)
 			ui.Error(err.Error())
 			return multistep.ActionHalt
+		}
+		if !s.AMISkipRunTags {
+			ui.Say("Attaching run tags to AMI...")
+			createOpts.TagSpecifications = ec2Tags.TagSpecifications(ec2.ResourceTypeImage, ec2.ResourceTypeSnapshot)
+		} else {
+			ui.Say("Skipping attaching run tags to AMI...")
 		}
 
 		createOpts.TagSpecifications = ec2Tags.TagSpecifications(ec2.ResourceTypeImage, ec2.ResourceTypeSnapshot)

--- a/builder/ebssurrogate/step_create_ami.go
+++ b/builder/ebssurrogate/step_create_ami.go
@@ -80,8 +80,6 @@ func (s *StepCreateAMI) Run(ctx context.Context, state multistep.StateBag) multi
 		} else {
 			ui.Say("Skipping attaching run tags to AMI...")
 		}
-
-		createOpts.TagSpecifications = ec2Tags.TagSpecifications(ec2.ResourceTypeImage, ec2.ResourceTypeSnapshot)
 	}
 
 	var createResp *ec2.CreateImageOutput

--- a/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_basic.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_basic.pkr.hcl
@@ -1,0 +1,25 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_basic_imdsv2.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_basic_imdsv2.pkr.hcl
@@ -1,0 +1,26 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	imds_support = "v2.0"
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_create_image.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_create_image.pkr.hcl
@@ -1,0 +1,26 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	use_create_image = true
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_create_image_false.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_create_image_false.pkr.hcl
@@ -1,0 +1,26 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	use_create_image = false
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_create_image_optional.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_create_image_optional.pkr.hcl
@@ -1,0 +1,25 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_private_key_file.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_private_key_file.pkr.hcl
@@ -1,0 +1,29 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name             = "%s"
+	source_ami           = "ami-0b5eea76982371e91" # Amazon Linux 2 AMI - kernel 5.10
+	instance_type        = "m3.medium"
+	region               = "us-east-1"
+	ssh_username         = "ec2-user"
+	ssh_interface        = "session_manager"
+	iam_instance_profile = "SSMInstanceProfile"
+	communicator         = "ssh"
+	ssh_private_key_file = "%s"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_with_deprecate_at.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_ebs_surrogate_with_deprecate_at.pkr.hcl
@@ -1,0 +1,26 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	deprecate_at = "%s"
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/builder/ebssurrogate/test-fixtures/interpolated_skip_run_tags.pkr.hcl
+++ b/builder/ebssurrogate/test-fixtures/interpolated_skip_run_tags.pkr.hcl
@@ -1,0 +1,31 @@
+source "amazon-ebssurrogate" "test" {
+	ami_name = "%s"
+	region = "us-east-1"
+	instance_type = "m3.medium"
+	source_ami = "ami-76b2a71e"
+	ssh_username = "ubuntu"
+	launch_block_device_mappings {
+		device_name = "/dev/xvda"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	ami_virtualization_type = "hvm"
+	ami_root_device {
+		source_device_name = "/dev/xvda"
+		device_name = "/dev/sda1"
+		delete_on_termination = true
+		volume_size = 8
+		volume_type = "gp2"
+	}
+	run_tags = {
+    	"simple" = "Simple String"
+	}
+  skip_ami_run_tags = true
+  use_create_image = true
+
+}
+
+build {
+	sources = ["amazon-ebssurrogate.test"]
+}

--- a/docs-partials/builder/ebs/Config-not-required.mdx
+++ b/docs-partials/builder/ebs/Config-not-required.mdx
@@ -3,6 +3,8 @@
 - `skip_create_ami` (bool) - If true, Packer will not create the AMI. Useful for setting to `true`
   during a build test stage. Default `false`.
 
+- `skip_ami_run_tags` (bool) - If true will not propagate the run tags set on Packer created instance to the AMI created.
+
 - `ami_block_device_mappings` (awscommon.BlockDevices) - Add one or more block device mappings to the AMI. These will be attached
   when booting a new instance from your AMI. To add a block device during
   the Packer build see `launch_block_device_mappings` below. Your options

--- a/docs-partials/builder/ebssurrogate/Config-not-required.mdx
+++ b/docs-partials/builder/ebssurrogate/Config-not-required.mdx
@@ -8,6 +8,8 @@
   here may vary depending on the type of VM you use. See the
   [BlockDevices](#block-devices-configuration) documentation for fields.
 
+- `skip_ami_run_tags` (bool) - If true will not propagate the run tags set on Packer created instance to the AMI created.
+
 - `launch_block_device_mappings` (BlockDevices) - Add one or more block devices before the Packer build starts. If you add
   instance store volumes or EBS volumes in addition to the root device
   volume, the created AMI will contain block device mapping information


### PR DESCRIPTION
Provide a way to users to allow them to skip the tags that are created to be attached to the AMI.
As of today we propagate the tags that are set in run_tags to the AMI. I propose on adding a new config

**_skip_ami_run_tags_** : Setting this config to True would make sure the tags set in run_tags are not propagated to the finished AMI instance.

Closes: https://github.com/hashicorp/packer-plugin-amazon/issues/361