### PR TITLE
fix(docs): correct firewall command for WinRM HTTPS setup

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -2132,7 +2132,7 @@ cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
 cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
 cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTPS" "@{Port=`"5986`";Hostname=`"packer`";CertificateThumbprint=`"$($Cert.Thumbprint)`"}"
 cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
-cmd.exe /c netsh firewall add portopening TCP 5986 "Port 5986"
+cmd.exe /c netsh advfirewall firewall add rule name="Port 5986" dir=in action=allow protocol=TCP localport=5986 profile=any
 cmd.exe /c net stop winrm
 cmd.exe /c sc config winrm start= auto
 cmd.exe /c net start winrm

--- a/docs/builders/ebs.mdx
+++ b/docs/builders/ebs.mdx
@@ -590,7 +590,7 @@ cmd.exe /c winrm set "winrm/config/client/auth" '@{Basic="true"}'
 cmd.exe /c winrm set "winrm/config/service/auth" '@{CredSSP="true"}'
 cmd.exe /c winrm set "winrm/config/listener?Address=*+Transport=HTTPS" "@{Port=`"5986`";Hostname=`"packer`";CertificateThumbprint=`"$($Cert.Thumbprint)`"}"
 cmd.exe /c netsh advfirewall firewall set rule group="remote administration" new enable=yes
-cmd.exe /c netsh firewall add portopening TCP 5986 "Port 5986"
+cmd.exe /c netsh advfirewall firewall add rule name="Port 5986" dir=in action=allow protocol=TCP localport=5986 profile=any
 cmd.exe /c net stop winrm
 cmd.exe /c sc config winrm start= auto
 cmd.exe /c net start winrm


### PR DESCRIPTION
This PR updates the firewall rule creation command to ensure it applies to all network profiles (Public, Private, and Domain) instead of being limited to the Public profile.

Issue: The old command implicitly applied the firewall rule only to the Public network profile. This could cause issues if a user changes their network profile to Private or Domain, as the rule would no longer be effective, potentially blocking traffic on port 5986.

This change ensures that port 5986 remains open regardless of the active network profile. It addresses potential issues where the rule would not be applied if the user's network profile switched from public to private, thereby preventing unintended connectivity problems. (i/o timeout issues)