### PR TITLE
release `v1.3.9`

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -6,8 +6,8 @@ package version
 import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
-	Version           = "1.3.9"
-	VersionPrerelease = ""
+	Version           = "1.3.10"
+	VersionPrerelease = "dev"
 	VersionMetadata   = ""
 	PluginVersion     = version.NewPluginVersion(Version, VersionPrerelease, VersionMetadata)
 )


### PR DESCRIPTION
- **version: cut release v1.3.9**
- **version: prepare v1.3.10-dev**

----

### Description
This pr contain the commits required for release version `v1.3.9`



