### PR TITLE
Common Helper methods

### DIFF
--- a/common/state.go
+++ b/common/state.go
@@ -3,6 +3,7 @@
 
 //go:generate packer-sdc struct-markdown
 //go:generate packer-sdc mapstructure-to-hcl2 -type AWSPollingConfig
+//nolint:all #todo: adding this for now (to allow us to merge), will remove it once we start using the common methods
 package common
 
 import (

--- a/docs-partials/common/AWSPollingConfig-not-required.mdx
+++ b/docs-partials/common/AWSPollingConfig-not-required.mdx
@@ -4,6 +4,8 @@
   This value can also be set via the AWS_MAX_ATTEMPTS.
   If both option and environment variable are set, the max_attempts will be considered over the AWS_MAX_ATTEMPTS.
   If none is set, defaults to AWS waiter default which is 40 max_attempts.
+  In aws sdk go v2, the max attempts is not set directly, but rather set via max wait time and delay seconds.
+  maxWaitTime = maxAttempts * delaySeconds
 
 - `delay_seconds` (int) - Specifies the delay in seconds between attempts to check the resource state.
   This value can also be set via the AWS_POLL_DELAY_SECONDS.


### PR DESCRIPTION
As part of our effort to migrate our components to Aws Sdk go v2, we need to have certain common methods that are to be used in different branches created for different components, This PR aims to address that, we can safely merge this PR to main and rebase respective upgrade branches to use these methods.