### PR TITLE
fix UserAgentProducts when building the request.

### DIFF
--- a/common/access_config.go
+++ b/common/access_config.go
@@ -282,8 +282,6 @@ func (c *AccessConfig) getBaseAwsConfig(ctx context.Context) (aws.Config, error)
 		imdsEnabledState = imds.ClientDisabled
 	}
 	userAgentProducts := awsbase.UserAgentProducts{
-		{Name: "APN", Version: "1.0"},
-		{Name: "HashiCorp", Version: "1.0"},
 		{Name: "packer-plugin-amazon", Version: pluginversion.Version, Comment: "+https://www.packer.io/docs/builders/amazon"},
 	}
 
@@ -296,9 +294,7 @@ func (c *AccessConfig) getBaseAwsConfig(ctx context.Context) (aws.Config, error)
 		AccessKey: c.AccessKey,
 		APNInfo: &awsbase.APNInfo{
 			PartnerName: "HashiCorp",
-			Products: []awsbase.UserAgentProduct{
-				{Name: "packer-plugin-amazon", Version: pluginversion.Version, Comment: "+https://www.packer.io/docs/builders/amazon"},
-			},
+			Products:    userAgentProducts,
 		},
 		Region:           c.RawRegion,
 		SuppressDebugLog: true,


### PR DESCRIPTION
Currently when building the config, we are passing UserAgentProducts as part of the [Config](https://github.com/hashicorp/aws-sdk-go-base/blob/main/internal/config/config.go#L73) struct. But if `TF_APPEND_USER_AGENT` environment variable is set, this causes a collision as both the `UserAgentProducts` and the env var were using the same ID in the middleware Stack BuildStep. This collision was causing the build to fail.

Also  default User-Agent middleware prepends itself to the contents of the User-Agent header, we have to prepend our custom User-Agent. This happens if we set the UserAgentProducts in the `APNInfo`

Closes: https://github.com/hashicorp/packer-plugin-amazon/issues/599

Screenshot of how the user agent will look like

<img width="1390" height="24" alt="Screenshot 2025-09-03 at 5 14 56 PM" src="https://github.com/user-attachments/assets/a03d9f3a-ad18-421a-80f4-f9af55cd8917" />


