### PR TITLE
Add PACKER_PATH arg to makefile to overcome conflicting cracklib packer in certain distributions

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,6 +6,8 @@ COUNT?=1
 TEST?=$(shell go list ./...)
 HASHICORP_PACKER_PLUGIN_SDK_VERSION?=$(shell go list -m github.com/hashicorp/packer-plugin-sdk | cut -d " " -f2)
 
+PACKER_PATH?=packer
+
 .PHONY: dev
 
 build:
@@ -13,9 +15,8 @@ build:
 
 dev:
 	@go build -ldflags="-X '${PLUGIN_FQN}/version.VersionPrerelease=dev'" -o '${BINARY}'
-	packer plugins install --path ${BINARY} "$(shell echo "${PLUGIN_FQN}" | sed 's/packer-plugin-//')"
+	${PACKER_PATH} plugins install --path ${BINARY} "$(shell echo "${PLUGIN_FQN}" | sed 's/packer-plugin-//')"
 
-test:
 	@go test -race -count $(COUNT) $(TEST) -timeout=3m
 
 install-packer-sdc: ## Install packer sofware development command


### PR DESCRIPTION
### Description
What code changed, and why?
Adds a PACKER_PATH arg to GNUmakefile that defaults to 'packer' to deal with conflicts of the cracklib packer tool.

As described in [troubleshooting packer issues](https://developer.hashicorp.com/packer/tutorials/docker-get-started/get-started-install-cli#troubleshooting)

### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #604 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? None

