### PR TITLE
feat: add subnet_ids for multi-AZ spot instance failover

### DIFF
--- a/.web-docs/components/builder/ebs/README.md
+++ b/.web-docs/components/builder/ebs/README.md
@@ -909,6 +909,12 @@ JSON example:
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
+- `subnet_ids` ([]string) - A list of subnet IDs to launch the instance in. When used with
+  spot_instance_types, EC2 Fleet will try all combinations of instance
+  types and subnets, enabling automatic failover across availability zones
+  when capacity is constrained. This is mutually exclusive with subnet_id
+  and subnet_filter.
+
 - `license_specifications` ([]LicenseSpecification) - The license configurations.
   
   HCL2 example:

--- a/.web-docs/components/builder/ebssurrogate/README.md
+++ b/.web-docs/components/builder/ebssurrogate/README.md
@@ -922,6 +922,12 @@ JSON example:
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
+- `subnet_ids` ([]string) - A list of subnet IDs to launch the instance in. When used with
+  spot_instance_types, EC2 Fleet will try all combinations of instance
+  types and subnets, enabling automatic failover across availability zones
+  when capacity is constrained. This is mutually exclusive with subnet_id
+  and subnet_filter.
+
 - `license_specifications` ([]LicenseSpecification) - The license configurations.
   
   HCL2 example:

--- a/.web-docs/components/builder/ebsvolume/README.md
+++ b/.web-docs/components/builder/ebsvolume/README.md
@@ -856,6 +856,12 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/block-device-mapping-concept
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
+- `subnet_ids` ([]string) - A list of subnet IDs to launch the instance in. When used with
+  spot_instance_types, EC2 Fleet will try all combinations of instance
+  types and subnets, enabling automatic failover across availability zones
+  when capacity is constrained. This is mutually exclusive with subnet_id
+  and subnet_filter.
+
 - `license_specifications` ([]LicenseSpecification) - The license configurations.
   
   HCL2 example:

--- a/.web-docs/components/builder/instance/README.md
+++ b/.web-docs/components/builder/instance/README.md
@@ -905,6 +905,12 @@ JSON example:
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
+- `subnet_ids` ([]string) - A list of subnet IDs to launch the instance in. When used with
+  spot_instance_types, EC2 Fleet will try all combinations of instance
+  types and subnets, enabling automatic failover across availability zones
+  when capacity is constrained. This is mutually exclusive with subnet_id
+  and subnet_filter.
+
 - `license_specifications` ([]LicenseSpecification) - The license configurations.
   
   HCL2 example:

--- a/builder/common/run_config.go
+++ b/builder/common/run_config.go
@@ -504,6 +504,12 @@ type RunConfig struct {
 	// subnet-12345def, where Packer will launch the EC2 instance. This field is
 	// required if you are using an non-default VPC.
 	SubnetId string `mapstructure:"subnet_id" required:"false"`
+	// A list of subnet IDs to launch the instance in. When used with
+	// spot_instance_types, EC2 Fleet will try all combinations of instance
+	// types and subnets, enabling automatic failover across availability zones
+	// when capacity is constrained. This is mutually exclusive with subnet_id
+	// and subnet_filter.
+	SubnetIds []string `mapstructure:"subnet_ids" required:"false"`
 	// The license configurations.
 	//
 	// HCL2 example:
@@ -868,6 +874,18 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		} else {
 			c.SecurityGroupIds = []string{c.SecurityGroupId}
 			c.SecurityGroupId = ""
+		}
+	}
+
+	if len(c.SubnetIds) > 0 {
+		if c.SubnetId != "" {
+			errs = append(errs, fmt.Errorf("Only one of subnet_id or subnet_ids can be specified."))
+		}
+		if !c.SubnetFilter.Empty() {
+			errs = append(errs, fmt.Errorf("Only one of subnet_ids or subnet_filter can be specified."))
+		}
+		if len(c.SpotInstanceTypes) == 0 {
+			errs = append(errs, fmt.Errorf("subnet_ids requires spot_instance_types to use EC2 Fleet for multi-AZ failover."))
 		}
 	}
 

--- a/builder/common/run_config_test.go
+++ b/builder/common/run_config_test.go
@@ -612,3 +612,51 @@ func TestRunConfigPrepare_SSHInterfaceIPv6_DefaultCIDR(t *testing.T) {
 		t.Errorf("expected default CIDR to be '::/0', got: %s", c.TemporarySGSourceCidrs[0])
 	}
 }
+
+func TestRunConfigPrepare_SubnetIdsWithSubnetId(t *testing.T) {
+	c := testConfig()
+	c.SubnetIds = []string{"subnet-abc123", "subnet-def456"}
+	c.SubnetId = "subnet-xyz789"
+	c.SpotInstanceTypes = []string{"t3.micro", "t3.small"}
+	c.InstanceType = ""
+
+	errs := c.Prepare(nil)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for subnet_ids with subnet_id, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestRunConfigPrepare_SubnetIdsWithSubnetFilter(t *testing.T) {
+	c := testConfig()
+	c.SubnetIds = []string{"subnet-abc123", "subnet-def456"}
+	c.SubnetFilter.Filters = map[string]string{"tag:Environment": "build"}
+	c.SpotInstanceTypes = []string{"t3.micro", "t3.small"}
+	c.InstanceType = ""
+
+	errs := c.Prepare(nil)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for subnet_ids with subnet_filter, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestRunConfigPrepare_SubnetIdsWithoutSpotInstanceTypes(t *testing.T) {
+	c := testConfig()
+	c.SubnetIds = []string{"subnet-abc123", "subnet-def456"}
+
+	errs := c.Prepare(nil)
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error for subnet_ids without spot_instance_types, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestRunConfigPrepare_SubnetIdsWithSpotInstanceTypes(t *testing.T) {
+	c := testConfig()
+	c.SubnetIds = []string{"subnet-abc123", "subnet-def456"}
+	c.SpotInstanceTypes = []string{"t3.micro", "t3.small"}
+	c.InstanceType = ""
+
+	errs := c.Prepare(nil)
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors for subnet_ids with spot_instance_types, got %d: %v", len(errs), errs)
+	}
+}

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -247,6 +247,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SpotTags:                          b.config.SpotTags,
 			Tags:                              b.config.RunTags,
 			SpotInstanceTypes:                 b.config.SpotInstanceTypes,
+			SubnetIds:                         b.config.SubnetIds,
 			SpotAllocationStrategy:            b.config.SpotAllocationStrategy,
 			UserData:                          b.config.UserData,
 			UserDataFile:                      b.config.UserDataFile,

--- a/builder/ebs/builder.hcl2spec.go
+++ b/builder/ebs/builder.hcl2spec.go
@@ -97,6 +97,7 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                       `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions             `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                     `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	SubnetIds                                 []string                                    `mapstructure:"subnet_ids" required:"false" cty:"subnet_ids" hcl:"subnet_ids"`
 	LicenseSpecifications                     []common.FlatLicenseSpecification           `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
 	Placement                                 *common.FlatPlacement                       `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                     `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
@@ -267,6 +268,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"subnet_ids":                            &hcldec.AttrSpec{Name: "subnet_ids", Type: cty.List(cty.String), Required: false},
 		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
 		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},

--- a/builder/ebssurrogate/builder.go
+++ b/builder/ebssurrogate/builder.go
@@ -284,6 +284,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SpotPrice:                         b.config.SpotPrice,
 			SpotAllocationStrategy:            b.config.SpotAllocationStrategy,
 			SpotInstanceTypes:                 b.config.SpotInstanceTypes,
+			SubnetIds:                         b.config.SubnetIds,
 			SpotTags:                          b.config.SpotTags,
 			Tags:                              b.config.RunTags,
 			UserData:                          b.config.UserData,

--- a/builder/ebssurrogate/builder.hcl2spec.go
+++ b/builder/ebssurrogate/builder.hcl2spec.go
@@ -114,6 +114,7 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                       `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions             `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                     `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	SubnetIds                                 []string                                    `mapstructure:"subnet_ids" required:"false" cty:"subnet_ids" hcl:"subnet_ids"`
 	LicenseSpecifications                     []common.FlatLicenseSpecification           `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
 	Placement                                 *common.FlatPlacement                       `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                     `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
@@ -288,6 +289,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"subnet_ids":                            &hcldec.AttrSpec{Name: "subnet_ids", Type: cty.List(cty.String), Required: false},
 		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
 		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},

--- a/builder/ebsvolume/builder.go
+++ b/builder/ebsvolume/builder.go
@@ -228,6 +228,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Region:                            awsConfig.Region,
 			SourceAMI:                         b.config.SourceAmi,
 			SpotInstanceTypes:                 b.config.SpotInstanceTypes,
+			SubnetIds:                         b.config.SubnetIds,
 			SpotAllocationStrategy:            b.config.SpotAllocationStrategy,
 			SpotPrice:                         b.config.SpotPrice,
 			SpotTags:                          b.config.SpotTags,

--- a/builder/ebsvolume/builder.hcl2spec.go
+++ b/builder/ebsvolume/builder.hcl2spec.go
@@ -128,6 +128,7 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                  `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions        `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	SubnetIds                                 []string                               `mapstructure:"subnet_ids" required:"false" cty:"subnet_ids" hcl:"subnet_ids"`
 	LicenseSpecifications                     []common.FlatLicenseSpecification      `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
 	Placement                                 *common.FlatPlacement                  `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
@@ -267,6 +268,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"subnet_ids":                            &hcldec.AttrSpec{Name: "subnet_ids", Type: cty.List(cty.String), Required: false},
 		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
 		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},

--- a/builder/instance/builder.go
+++ b/builder/instance/builder.go
@@ -294,6 +294,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			SourceAMI:                b.config.SourceAmi,
 			SpotPrice:                b.config.SpotPrice,
 			SpotInstanceTypes:        b.config.SpotInstanceTypes,
+			SubnetIds:                b.config.SubnetIds,
 			SpotAllocationStrategy:   b.config.SpotAllocationStrategy,
 			Tags:                     b.config.RunTags,
 			SpotTags:                 b.config.SpotTags,

--- a/builder/instance/builder.hcl2spec.go
+++ b/builder/instance/builder.hcl2spec.go
@@ -97,6 +97,7 @@ type FlatConfig struct {
 	SpotTag                                   []config.FlatKeyValue                       `mapstructure:"spot_tag" required:"false" cty:"spot_tag" hcl:"spot_tag"`
 	SubnetFilter                              *common.FlatSubnetFilterOptions             `mapstructure:"subnet_filter" required:"false" cty:"subnet_filter" hcl:"subnet_filter"`
 	SubnetId                                  *string                                     `mapstructure:"subnet_id" required:"false" cty:"subnet_id" hcl:"subnet_id"`
+	SubnetIds                                 []string                                    `mapstructure:"subnet_ids" required:"false" cty:"subnet_ids" hcl:"subnet_ids"`
 	LicenseSpecifications                     []common.FlatLicenseSpecification           `mapstructure:"license_specifications" required:"false" cty:"license_specifications" hcl:"license_specifications"`
 	Placement                                 *common.FlatPlacement                       `mapstructure:"placement" required:"false" cty:"placement" hcl:"placement"`
 	Tenancy                                   *string                                     `mapstructure:"tenancy" required:"false" cty:"tenancy" hcl:"tenancy"`
@@ -271,6 +272,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"spot_tag":                              &hcldec.BlockListSpec{TypeName: "spot_tag", Nested: hcldec.ObjectSpec((*config.FlatKeyValue)(nil).HCL2Spec())},
 		"subnet_filter":                         &hcldec.BlockSpec{TypeName: "subnet_filter", Nested: hcldec.ObjectSpec((*common.FlatSubnetFilterOptions)(nil).HCL2Spec())},
 		"subnet_id":                             &hcldec.AttrSpec{Name: "subnet_id", Type: cty.String, Required: false},
+		"subnet_ids":                            &hcldec.AttrSpec{Name: "subnet_ids", Type: cty.List(cty.String), Required: false},
 		"license_specifications":                &hcldec.BlockListSpec{TypeName: "license_specifications", Nested: hcldec.ObjectSpec((*common.FlatLicenseSpecification)(nil).HCL2Spec())},
 		"placement":                             &hcldec.BlockSpec{TypeName: "placement", Nested: hcldec.ObjectSpec((*common.FlatPlacement)(nil).HCL2Spec())},
 		"tenancy":                               &hcldec.AttrSpec{Name: "tenancy", Type: cty.String, Required: false},

--- a/common/run_config.go
+++ b/common/run_config.go
@@ -501,6 +501,12 @@ type RunConfig struct {
 	// subnet-12345def, where Packer will launch the EC2 instance. This field is
 	// required if you are using an non-default VPC.
 	SubnetId string `mapstructure:"subnet_id" required:"false"`
+	// A list of subnet IDs to launch the instance in. When used with
+	// spot_instance_types, EC2 Fleet will try all combinations of instance
+	// types and subnets, enabling automatic failover across availability zones
+	// when capacity is constrained. This is mutually exclusive with subnet_id
+	// and subnet_filter.
+	SubnetIds []string `mapstructure:"subnet_ids" required:"false"`
 	// The license configurations.
 	//
 	// HCL2 example:
@@ -861,6 +867,18 @@ func (c *RunConfig) Prepare(ctx *interpolate.Context) []error {
 		} else {
 			c.SecurityGroupIds = []string{c.SecurityGroupId}
 			c.SecurityGroupId = ""
+		}
+	}
+
+	if len(c.SubnetIds) > 0 {
+		if c.SubnetId != "" {
+			errs = append(errs, fmt.Errorf("Only one of subnet_id or subnet_ids can be specified."))
+		}
+		if !c.SubnetFilter.Empty() {
+			errs = append(errs, fmt.Errorf("Only one of subnet_ids or subnet_filter can be specified."))
+		}
+		if len(c.SpotInstanceTypes) == 0 {
+			errs = append(errs, fmt.Errorf("subnet_ids requires spot_instance_types to use EC2 Fleet for multi-AZ failover."))
 		}
 	}
 

--- a/docs-partials/builder/common/RunConfig-not-required.mdx
+++ b/docs-partials/builder/common/RunConfig-not-required.mdx
@@ -372,6 +372,12 @@
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
+- `subnet_ids` ([]string) - A list of subnet IDs to launch the instance in. When used with
+  spot_instance_types, EC2 Fleet will try all combinations of instance
+  types and subnets, enabling automatic failover across availability zones
+  when capacity is constrained. This is mutually exclusive with subnet_id
+  and subnet_filter.
+
 - `license_specifications` ([]LicenseSpecification) - The license configurations.
   
   HCL2 example:

--- a/docs-partials/common/RunConfig-not-required.mdx
+++ b/docs-partials/common/RunConfig-not-required.mdx
@@ -373,6 +373,12 @@
   subnet-12345def, where Packer will launch the EC2 instance. This field is
   required if you are using an non-default VPC.
 
+- `subnet_ids` ([]string) - A list of subnet IDs to launch the instance in. When used with
+  spot_instance_types, EC2 Fleet will try all combinations of instance
+  types and subnets, enabling automatic failover across availability zones
+  when capacity is constrained. This is mutually exclusive with subnet_id
+  and subnet_filter.
+
 - `license_specifications` ([]LicenseSpecification) - The license configurations.
   
   HCL2 example:


### PR DESCRIPTION
### Description

Add a new `subnet_ids` parameter that allows users to specify multiple subnets for spot instances. When used with `spot_instance_types`, EC2 Fleet receives overrides for all instance type × subnet combinations, enabling automatic failover when capacity is constrained.

Example configuration:
```hcl
source "amazon-ebs" "example" {
  spot_price          = "auto"
  spot_instance_types = ["m6i.large", "m5.large", "m6a.large"]
  subnet_ids          = ["subnet-abc123", "subnet-def456", "subnet-ghi789"]
}
```

This gives EC2 Fleet 9 placement options (3 instance types × 3 subnets) to choose from.

**How it works:**
- When `subnet_ids` is set, the launch template omits Placement/subnet
- Fleet overrides include the Cartesian product of instance types × subnets
- EC2 Fleet selects an available combination at launch time
- Existing `subnet_id` and `subnet_filter` behavior is unchanged

### Resolved Issues

Closes #425

### Rollback Plan

This change is additive and backward compatible. To rollback, revert the commit. Existing configurations using `subnet_id` or `subnet_filter` are unaffected.

### Changes to Security Controls

No changes to security controls (access controls, encryption, logging).