### PR TITLE
fix: ensure temporary IAM role is removed on EC2 dry-run or attach failure

### DIFF
--- a/builder/common/step_iam_instance_profile.go
+++ b/builder/common/step_iam_instance_profile.go
@@ -170,7 +170,7 @@ func (s *StepIamInstanceProfile) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packersdk.Ui)
 	var err error
 
-	if s.roleIsAttached == true {
+	if s.createdRoleName != "" {
 		ui.Say("Detaching temporary role from instance profile...")
 
 		_, err := iamsvc.RemoveRoleFromInstanceProfile(&iam.RemoveRoleFromInstanceProfileInput{

--- a/common/step_iam_instance_profile.go
+++ b/common/step_iam_instance_profile.go
@@ -246,7 +246,7 @@ func (s *StepIamInstanceProfile) Cleanup(state multistep.StateBag) {
 	ui := state.Get("ui").(packersdk.Ui)
 	var err error
 
-	if s.roleIsAttached == true {
+	if s.createdRoleName != "" {
 		ui.Say("Detaching temporary role from instance profile...")
 
 		_, err := iamsvc.RemoveRoleFromInstanceProfile(ctx, &iam.RemoveRoleFromInstanceProfileInput{


### PR DESCRIPTION
### Description

A temporary IAM role is created but not cleaned up when an error occurs while attaching the role to the instance profile.
https://github.com/hashicorp/packer-plugin-amazon/blob/49961bec5134e26ccf769adb7273cd6c33fdc592/builder/common/step_iam_instance_profile.go#L151-L159

The same issue also occurs when an error is returned during the EC2 dry-run test.
https://github.com/hashicorp/packer-plugin-amazon/blob/49961bec5134e26ccf769adb7273cd6c33fdc592/common/step_iam_instance_profile.go#L229-L234

The root clause is the code skips setting `s.roleIsAttached = true`. This PR ensures that the temporary role is properly removed in both failure scenarios.

A excerpt of packer log:
```
2026/02/16 13:24:11 ui: 2026-02-16T13:24:11+08:00: ==> ubuntu.amazon-ebssurrogate.jammy: Deleting temporary role...
2026/02/16 13:24:11 ui error: 2026-02-16T13:24:11+08:00: ==> ubuntu.amazon-ebssurrogate.jammy: Error operation error IAM: DeleteRole, https response error StatusCode: 409, RequestID: d1062ddd-a4a5-4032-a2ec-6a84c7514b9d, DeleteConflict: Cannot delete entity, must remove roles from instance profile first.. Please delete the role manually: packer-6992a9f0-07ce-f274-22b5-311327335af4
2026/02/16 13:24:11 ui: 2026-02-16T13:24:11+08:00: ==> ubuntu.amazon-ebssurrogate.jammy: Deleting temporary instance profile...
2026/02/16 13:24:12 ui error: 2026-02-16T13:24:12+08:00: ==> ubuntu.amazon-ebssurrogate.jammy: Error operation error IAM: DeleteInstanceProfile, https response error StatusCode: 409, RequestID: d349dd8a-9c8f-48e6-9242-fecbb5e986ae, DeleteConflict: Cannot delete entity, must remove roles from instance profile first.. Please delete the instance profile manually: packer-6992a9f0-07ce-f274-22b5-311327335af4
```

### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No