### PR TITLE
fix: match EC2 instance type to source AMI architecture in dry run

### DIFF
--- a/common/step_iam_instance_profile.go
+++ b/common/step_iam_instance_profile.go
@@ -188,9 +188,7 @@ func (s *StepIamInstanceProfile) Run(ctx context.Context, state multistep.StateB
 		}
 		sourceImage := sourceImageRaw.(*ec2types.Image)
 		instanceType := map[ec2types.ArchitectureValues]ec2types.InstanceType{
-			ec2types.ArchitectureValuesArm64:    ec2types.InstanceTypeT4gNano,
-			ec2types.ArchitectureValuesX8664Mac: ec2types.InstanceTypeMac1Metal,
-			ec2types.ArchitectureValuesArm64Mac: ec2types.InstanceTypeMac2Metal,
+			ec2types.ArchitectureValuesArm64: ec2types.InstanceTypeT4gNano,
 		}[sourceImage.Architecture]
 		if instanceType == "" {
 			instanceType = ec2types.InstanceTypeT3Nano


### PR DESCRIPTION
### Description
During EC2 dry-run, packer currently uses a default `t3.nano` instance type which does not match the architecture of the source AMI. This causes the dry-run fail.

The derivation of instance type should be based on the source architecture. If not matched, use `t3.nano` in default.
```
arm64      => t4g.nano
x86_64_mac => mac1.metal
arm64_mac  => mac2.metal
```

A excerpt of packer log:

```
2026/02/16 13:24:14 ui error: 2026-02-16T13:24:14+08:00: Build 'ubuntu.amazon-ebssurrogate.jammy' errored after 20 seconds 237 milliseconds: timed out waiting for IAM changes to propagate to EC2: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: f4b8cf2f-7a3d-4b88-b444-0541cbe3eb31, api error InvalidParameterValue: The architecture 'x86_64' of the specified instance type does not match the architecture 'arm64' of the specified AMI. Specify an instance type and an AMI that have matching architectures, and try again. You can use 'describe-instance-types' or 'describe-images' to discover the architecture of the instance type or AMI.
```


### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No