### PR TITLE
Fix ShouldRetry callbacks to name error parameter for correct retry behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Please refer to [releases](https://github.com/hashicorp/packer-plugin-amazon/releases) for the latest CHANGELOG information.
 ---
+## x.x.x (Unreleased)
+
+## 🐛 Bug Fixes
+- **Fix ShouldRetry callbacks not receiving error from retry framework** – by @tjouni
+  Several `ShouldRetry` callbacks had unnamed function parameters, causing them to
+  reference the outer scope's error variable instead of the error passed by the retry
+  framework. This prevented retries from working for transient AWS API errors such as
+  `InvalidAMIID.NotFound`, `InvalidSnapshot.NotFound`, and `InvalidInstanceID.NotFound`.
+
+---
 ## 1.8.0 (November 19, 2025)
 
 ## ✨ Features

--- a/builder/common/step_create_tags.go
+++ b/builder/common/step_create_tags.go
@@ -102,7 +102,7 @@ func (s *StepCreateTags) Run(ctx context.Context, state multistep.StateBag) mult
 		snapshotTags.Report(ui)
 
 		// Retry creating tags for about 2.5 minutes
-		err = retry.Config{Tries: 11, ShouldRetry: func(error) bool {
+		err = retry.Config{Tries: 11, ShouldRetry: func(err error) bool {
 			if awserrors.Matches(err, "InvalidAMIID.NotFound", "") || awserrors.Matches(err, "InvalidSnapshot.NotFound", "") {
 				return true
 			}

--- a/builder/common/step_run_source_instance.go
+++ b/builder/common/step_run_source_instance.go
@@ -364,7 +364,7 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	if s.IsRestricted {
 		ec2Tags.Report(ui)
 		// Retry creating tags for about 2.5 minutes
-		err = retry.Config{Tries: 11, ShouldRetry: func(error) bool {
+		err = retry.Config{Tries: 11, ShouldRetry: func(err error) bool {
 			if awserrors.Matches(err, "InvalidInstanceID.NotFound", "") {
 				return true
 			}

--- a/builder/common/step_run_spot_instance.go
+++ b/builder/common/step_run_spot_instance.go
@@ -510,7 +510,7 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		// Apply tags to the spot request.
 		err = retry.Config{
 			Tries:       11,
-			ShouldRetry: func(error) bool { return false },
+			ShouldRetry: func(err error) bool { return false },
 			RetryDelay:  (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 		}.Run(ctx, func(ctx context.Context) error {
 			_, err := ec2conn.CreateTags(&ec2.CreateTagsInput{

--- a/builder/common/step_stop_ebs_instance.go
+++ b/builder/common/step_stop_ebs_instance.go
@@ -45,7 +45,7 @@ func (s *StepStopEBSBackedInstance) Run(ctx context.Context, state multistep.Sta
 		// does not exist.
 
 		// Work around this by retrying a few times, up to about 5 minutes.
-		err := retry.Config{Tries: 6, ShouldRetry: func(error) bool {
+		err := retry.Config{Tries: 6, ShouldRetry: func(err error) bool {
 			if awserrors.Matches(err, "InvalidInstanceID.NotFound", "") {
 				return true
 			}

--- a/common/step_create_tags.go
+++ b/common/step_create_tags.go
@@ -106,7 +106,7 @@ func (s *StepCreateTags) Run(ctx context.Context, state multistep.StateBag) mult
 		snapshotTags.Report(ui)
 
 		// Retry creating tags for about 2.5 minutes
-		err = retry.Config{Tries: 11, ShouldRetry: func(error) bool {
+		err = retry.Config{Tries: 11, ShouldRetry: func(err error) bool {
 			if awserrors.Matches(err, "InvalidAMIID.NotFound", "") || awserrors.Matches(err, "InvalidSnapshot.NotFound", "") {
 				return true
 			}

--- a/common/step_run_source_instance.go
+++ b/common/step_run_source_instance.go
@@ -368,7 +368,7 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	if s.IsRestricted {
 		ec2Tags.Report(ui)
 		// Retry creating tags for about 2.5 minutes
-		err = retry.Config{Tries: 11, ShouldRetry: func(error) bool {
+		err = retry.Config{Tries: 11, ShouldRetry: func(err error) bool {
 			if awserrors.Matches(err, "InvalidInstanceID.NotFound", "") {
 				return true
 			}

--- a/common/step_run_spot_instance.go
+++ b/common/step_run_spot_instance.go
@@ -515,7 +515,7 @@ func (s *StepRunSpotInstance) Run(ctx context.Context, state multistep.StateBag)
 		// Apply tags to the spot request.
 		err = retry.Config{
 			Tries:       11,
-			ShouldRetry: func(error) bool { return false },
+			ShouldRetry: func(err error) bool { return false },
 			RetryDelay:  (&retry.Backoff{InitialBackoff: 200 * time.Millisecond, MaxBackoff: 30 * time.Second, Multiplier: 2}).Linear,
 		}.Run(ctx, func(ctx context.Context) error {
 			_, err := ec2Client.CreateTags(ctx, &ec2.CreateTagsInput{

--- a/common/step_stop_ebs_instance.go
+++ b/common/step_stop_ebs_instance.go
@@ -48,7 +48,7 @@ func (s *StepStopEBSBackedInstance) Run(ctx context.Context, state multistep.Sta
 		// does not exist.
 
 		// Work around this by retrying a few times, up to about 5 minutes.
-		err := retry.Config{Tries: 6, ShouldRetry: func(error) bool {
+		err := retry.Config{Tries: 6, ShouldRetry: func(err error) bool {
 			if awserrors.Matches(err, "InvalidInstanceID.NotFound", "") {
 				return true
 			}


### PR DESCRIPTION
### Description

Several `ShouldRetry` callbacks in `retry.Config` have unnamed `error` parameters,
causing the closure to capture the outer scope's `err` variable instead of the error
passed by the retry framework. This prevents retries from working for transient AWS
API errors such as `InvalidAMIID.NotFound`, `InvalidSnapshot.NotFound`, and
`InvalidInstanceID.NotFound`.

The fix names the function parameter (`func(err error) bool` instead of
`func(error) bool`), consistent with the pattern used elsewhere in this codebase
(e.g., `helper_funcs.go`, `step_pre_validate.go`, `step_run_source_instance.go`
lines 287/325).

#### Files changed

**Buggy callbacks fixed (6 files):**
- `builder/common/step_create_tags.go` — `InvalidAMIID.NotFound` / `InvalidSnapshot.NotFound`
- `builder/common/step_run_source_instance.go` — `InvalidInstanceID.NotFound` (restricted regions tagging)
- `builder/common/step_stop_ebs_instance.go` — `InvalidInstanceID.NotFound`
- `common/step_create_tags.go` — same (SDK v2 version)
- `common/step_run_source_instance.go` — same (SDK v2 version)
- `common/step_stop_ebs_instance.go` — same (SDK v2 version)

**Cosmetic fixes for consistency (2 files):**
- `builder/common/step_run_spot_instance.go` — `func(error) bool { return false }` (no behavioral change)
- `common/step_run_spot_instance.go` — same (SDK v2 version)

### Resolved Issues

Closes #661

Related: hashicorp/packer#10370 (Intermittent errors tagging AWS spot instances — root cause was this unnamed parameter bug preventing retries)

### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

No changes to security controls.