### PR TITLE
Skip EBS AMI preparation when no image is created

### DIFF
--- a/builder/common/step_modify_ebs_instance.go
+++ b/builder/common/step_modify_ebs_instance.go
@@ -19,17 +19,23 @@ type StepModifyEBSBackedInstance struct {
 	Skip                     bool
 	EnableAMIENASupport      config.Trilean
 	EnableAMISriovNetSupport bool
+	AMISkipCreateImage       bool
 }
 
 func (s *StepModifyEBSBackedInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ec2conn := state.Get("ec2").(ec2iface.EC2API)
-	instance := state.Get("instance").(*ec2.Instance)
-	ui := state.Get("ui").(packersdk.Ui)
-
 	// Skip when it is a spot instance
 	if s.Skip {
 		return multistep.ActionContinue
 	}
+
+	ui := state.Get("ui").(packersdk.Ui)
+	if s.AMISkipCreateImage {
+		ui.Say("skip_create_ami was set; skipping source instance attribute modification")
+		return multistep.ActionContinue
+	}
+
+	ec2conn := state.Get("ec2").(ec2iface.EC2API)
+	instance := state.Get("instance").(*ec2.Instance)
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)

--- a/builder/common/step_modify_ebs_instance_test.go
+++ b/builder/common/step_modify_ebs_instance_test.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
+)
+
+func TestStepModifyEBSBackedInstance_SkipCreateAMISkipsModification(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packersdk.TestUi(t))
+
+	step := &StepModifyEBSBackedInstance{
+		AMISkipCreateImage:       true,
+		EnableAMISriovNetSupport: true,
+		EnableAMIENASupport:      config.TriTrue,
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue, got %v", action)
+	}
+
+	if rawErr, ok := state.GetOk("error"); ok {
+		t.Fatalf("expected no error, got %v", rawErr)
+	}
+}

--- a/builder/common/step_stop_ebs_instance.go
+++ b/builder/common/step_stop_ebs_instance.go
@@ -19,17 +19,24 @@ type StepStopEBSBackedInstance struct {
 	PollingConfig       *AWSPollingConfig
 	Skip                bool
 	DisableStopInstance bool
+	AMISkipCreateImage  bool
 }
 
 func (s *StepStopEBSBackedInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ec2conn := state.Get("ec2").(*ec2.EC2)
-	instance := state.Get("instance").(*ec2.Instance)
 	ui := state.Get("ui").(packersdk.Ui)
 
 	// Skip when it is a spot instance
 	if s.Skip {
 		return multistep.ActionContinue
 	}
+
+	if s.AMISkipCreateImage {
+		ui.Say("skip_create_ami was set; skipping source instance stop")
+		return multistep.ActionContinue
+	}
+
+	ec2conn := state.Get("ec2").(*ec2.EC2)
+	instance := state.Get("instance").(*ec2.Instance)
 
 	var err error
 

--- a/builder/common/step_stop_ebs_instance_test.go
+++ b/builder/common/step_stop_ebs_instance_test.go
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+func TestStepStopEBSBackedInstance_SkipCreateAMISkipsStop(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packersdk.TestUi(t))
+
+	step := &StepStopEBSBackedInstance{
+		AMISkipCreateImage: true,
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue, got %v", action)
+	}
+
+	if rawErr, ok := state.GetOk("error"); ok {
+		t.Fatalf("expected no error, got %v", rawErr)
+	}
+}

--- a/builder/ebs/builder.go
+++ b/builder/ebs/builder.go
@@ -400,10 +400,12 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			PollingConfig:       b.config.PollingConfig,
 			Skip:                b.config.IsSpotInstance(),
 			DisableStopInstance: b.config.DisableStopInstance,
+			AMISkipCreateImage:  b.config.AMISkipCreateImage,
 		},
 		&awscommon.StepModifyEBSBackedInstance{
 			EnableAMISriovNetSupport: b.config.AMISriovNetSupport,
 			EnableAMIENASupport:      b.config.AMIENASupport,
+			AMISkipCreateImage:       b.config.AMISkipCreateImage,
 		},
 		&awscommon.StepDeregisterAMI{
 			AccessConfig:        &b.config.AccessConfig,

--- a/common/step_modify_ebs_instance.go
+++ b/common/step_modify_ebs_instance.go
@@ -20,17 +20,23 @@ type StepModifyEBSBackedInstance struct {
 	Skip                     bool
 	EnableAMIENASupport      config.Trilean
 	EnableAMISriovNetSupport bool
+	AMISkipCreateImage       bool
 }
 
 func (s *StepModifyEBSBackedInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ec2Client := state.Get("ec2v2").(clients.Ec2Client)
-	instance := state.Get("instance").(ec2types.Instance)
-	ui := state.Get("ui").(packersdk.Ui)
-
 	// Skip when it is a spot instance
 	if s.Skip {
 		return multistep.ActionContinue
 	}
+
+	ui := state.Get("ui").(packersdk.Ui)
+	if s.AMISkipCreateImage {
+		ui.Say("skip_create_ami was set; skipping source instance attribute modification")
+		return multistep.ActionContinue
+	}
+
+	ec2Client := state.Get("ec2v2").(clients.Ec2Client)
+	instance := state.Get("instance").(ec2types.Instance)
 
 	// Set SriovNetSupport to "simple". See http://goo.gl/icuXh5
 	// As of February 2017, this applies to C3, C4, D2, I2, R3, and M4 (excluding m4.16xlarge)

--- a/common/step_modify_ebs_instance_test.go
+++ b/common/step_modify_ebs_instance_test.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+	"github.com/hashicorp/packer-plugin-sdk/template/config"
+)
+
+func TestStepModifyEBSBackedInstance_SkipCreateAMISkipsModification(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packersdk.TestUi(t))
+
+	step := &StepModifyEBSBackedInstance{
+		AMISkipCreateImage:       true,
+		EnableAMISriovNetSupport: true,
+		EnableAMIENASupport:      config.TriTrue,
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue, got %v", action)
+	}
+
+	if rawErr, ok := state.GetOk("error"); ok {
+		t.Fatalf("expected no error, got %v", rawErr)
+	}
+}

--- a/common/step_stop_ebs_instance.go
+++ b/common/step_stop_ebs_instance.go
@@ -22,17 +22,24 @@ type StepStopEBSBackedInstance struct {
 	PollingConfig       *AWSPollingConfig
 	Skip                bool
 	DisableStopInstance bool
+	AMISkipCreateImage  bool
 }
 
 func (s *StepStopEBSBackedInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	ec2Client := state.Get("ec2v2").(clients.Ec2Client)
-	instance := state.Get("instance").(ec2types.Instance)
 	ui := state.Get("ui").(packersdk.Ui)
 
 	// Skip when it is a spot instance
 	if s.Skip {
 		return multistep.ActionContinue
 	}
+
+	if s.AMISkipCreateImage {
+		ui.Say("skip_create_ami was set; skipping source instance stop")
+		return multistep.ActionContinue
+	}
+
+	ec2Client := state.Get("ec2v2").(clients.Ec2Client)
+	instance := state.Get("instance").(ec2types.Instance)
 
 	var err error
 

--- a/common/step_stop_ebs_instance_test.go
+++ b/common/step_stop_ebs_instance_test.go
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2013, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+func TestStepStopEBSBackedInstance_SkipCreateAMISkipsStop(t *testing.T) {
+	state := new(multistep.BasicStateBag)
+	state.Put("ui", packersdk.TestUi(t))
+
+	step := &StepStopEBSBackedInstance{
+		AMISkipCreateImage: true,
+	}
+
+	action := step.Run(context.Background(), state)
+
+	if action != multistep.ActionContinue {
+		t.Fatalf("expected ActionContinue, got %v", action)
+	}
+
+	if rawErr, ok := state.GetOk("error"); ok {
+		t.Fatalf("expected no error, got %v", rawErr)
+	}
+}


### PR DESCRIPTION
### Description

This changes the Amazon EBS builder so `skip_create_ami = true` also reaches the source instance AMI preparation steps.

Today those steps can still stop the source instance and modify source instance attributes before the create image step observes `skip_create_ami`. For no image builds, I think those steps are AMI preparation work and can be skipped.

The patch passes `skip_create_ami` into:

1. `StepStopEBSBackedInstance`
2. `StepModifyEBSBackedInstance`

This PR intentionally does not change the final source instance termination wait. That behavior is a separate cleanup concern and can be discussed independently.

### Resolved Issues

Closes #680

### Evidence

I tested this with no image Amazon EBS runs that collect outputs before cleanup.

1. Full no image EBS run on `c5.metal` with Amazon plugin `1.8.1`
   The source instance stop wait took about `19m16s`.

2. Local patch that skips source stop and source attribute preparation
   Packer logged that source instance stop was skipped when `skip_create_ami = true`.

3. The remaining cleanup wait moved to final termination, which is why this PR avoids addressing that separate behavior.

### Validation

1. `go test ./builder/common ./common ./builder/ebs`
2. Git whitespace check on the amended commit

### Rollback Plan

Revert this change.

### Changes to Security Controls

No. This does not change access controls, encryption, or logging.
