### PR TITLE
Fix nil pointer panic when capacity_reservation_id is set without a preference

### DIFF
--- a/common/step_run_source_instance.go
+++ b/common/step_run_source_instance.go
@@ -260,6 +260,14 @@ func (s *StepRunSourceInstance) Run(ctx context.Context, state multistep.StateBa
 	}
 
 	if s.CapacityReservationId != "" || s.CapacityReservationGroupArn != "" {
+		// capacity_reservation_id / capacity_reservation_group_arn are mutually
+		// exclusive with capacity_reservation_preference (see RunConfig.Prepare),
+		// so when a target is set the preference block above did not allocate the
+		// specification. Allocate it here before setting the target, otherwise we
+		// dereference a nil pointer. See hashicorp/packer-plugin-amazon#684.
+		if runOpts.CapacityReservationSpecification == nil {
+			runOpts.CapacityReservationSpecification = &ec2types.CapacityReservationSpecification{}
+		}
 		runOpts.CapacityReservationSpecification.CapacityReservationTarget = &ec2types.CapacityReservationTarget{}
 
 		if s.CapacityReservationId != "" {


### PR DESCRIPTION
### Description

`amazon-ebs` (and any builder sharing `common.StepRunSourceInstance`) panics with a nil pointer dereference when `capacity_reservation_id` or `capacity_reservation_group_arn` is set.

`RunConfig.Prepare` treats `capacity_reservation_id` / `capacity_reservation_group_arn` and `capacity_reservation_preference` as mutually exclusive (`common/run_config.go`), so a valid On-Demand Capacity Reservation (ODCR) configuration leaves `capacity_reservation_preference` empty. But `StepRunSourceInstance.Run` only allocates `runOpts.CapacityReservationSpecification` when the preference is non-empty:

```go
if s.CapacityReservationPreference != "" {
    runOpts.CapacityReservationSpecification = &ec2types.CapacityReservationSpecification{
        CapacityReservationPreference: ec2types.CapacityReservationPreference(s.CapacityReservationPreference),
    }
}

if s.CapacityReservationId != "" || s.CapacityReservationGroupArn != "" {
    runOpts.CapacityReservationSpecification.CapacityReservationTarget = &ec2types.CapacityReservationTarget{} // nil deref
    ...
}
```

So when only the id/group ARN is set (the only configuration the validator allows for targeting a reservation), the build crashes:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation ...]
github.com/hashicorp/packer-plugin-amazon/common.(*StepRunSourceInstance).Run
    common/step_run_source_instance.go:263
```

This makes it impossible to launch a build into an ODCR — the only supported way to use these fields always panics.

The fix allocates the `CapacityReservationSpecification` when it is nil, before setting the target.

### Validation

- Reproduced the panic with the released **v1.8.1** plugin and with a local build of `main`, using Packer 1.15.4 and a real **`targeted`** ODCR for `r6i.4xlarge`.
- With the fix, the build launches the source instance **into** the ODCR (the reservation's `AvailableInstanceCount` goes `1 → 0` and the launched instance's `CapacityReservationId` matches the reservation), provisions, and tears down cleanly.
- `go vet ./common/` is clean and `go test ./common/ -run CapacityReservation` passes (including the existing `ID set to something, no preference, no error` case, which is exactly the path that previously panicked at runtime).

### Resolved Issues

Closes #684

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

None. This change only adds a nil-guard before constructing the EC2 `RunInstances` request; it does not alter access controls, encryption, or logging.
